### PR TITLE
Model normal

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -32,12 +32,15 @@ library
     Data.Map.Range
     Database.LSMTree
     Database.LSMTree.Common
+    Database.LSMTree.Model.Normal
     Database.LSMTree.Monoidal
     Database.LSMTree.Normal
 
   build-depends:
     , base                 >=4.14     && <4.19
+    , bytestring
     , containers
+    , cryptohash-sha256
     , fs-api               ^>=0.2
     , io-classes           ^>=1.2
     , strict-checked-vars  ^>=0.1.0.3
@@ -53,13 +56,18 @@ test-suite lsm-tree-test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          Main.hs
-  other-modules:    Test.Database.LSMTree
+  other-modules:
+    Test.Database.LSMTree
+    Test.Database.LSMTree.Model.Normal
+
   build-depends:
-    , base              >=4.14 && <4.19
+    , base                  >=4.14 && <4.19
+    , bytestring
     , fs-api
-    , fs-sim            ^>=0.2
-    , io-sim            ^>=1.2
+    , fs-sim                ^>=0.2
+    , io-sim                ^>=1.2
     , lsm-tree
+    , quickcheck-instances
     , tasty
     , tasty-quickcheck
 

--- a/src/Database/LSMTree/Model/Normal.hs
+++ b/src/Database/LSMTree/Model/Normal.hs
@@ -1,0 +1,277 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE RoleAnnotations     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Database.LSMTree.Model.Normal (
+    -- * Temporary placeholder types
+    SomeSerialisationConstraint (..)
+    -- * Tables
+  , Table
+  , empty
+    -- * Table querying and updates
+    -- ** Queries
+  , Range (..)
+  , LookupResult (..)
+  , lookups
+  , RangeLookupResult (..)
+  , rangeLookup
+    -- ** Updates
+  , Update (..)
+  , updates
+  , inserts
+  , deletes
+    -- ** Blobs
+  , BlobRef
+  , retrieveBlobs
+    -- * Snapshots
+  , snapshot
+    -- * Multiple writable table handles
+  , duplicate
+  ) where
+
+import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Data.ByteString as BS
+import           Data.Foldable (foldl')
+import           Data.Map (Map)
+import qualified Data.Map.Range as Map.R
+import qualified Data.Map.Strict as Map
+import           Database.LSMTree.Normal (Range (..))
+import           GHC.Exts (IsList (..))
+
+{-------------------------------------------------------------------------------
+  Temporary placeholder types
+-------------------------------------------------------------------------------}
+
+class SomeSerialisationConstraint a where
+    serialise :: a -> BS.ByteString
+
+    -- Note: cannot fail.
+    deserialise :: BS.ByteString -> a
+
+instance SomeSerialisationConstraint BS.ByteString where
+    serialise = id
+    deserialise = id
+
+{-------------------------------------------------------------------------------
+  Tables
+-------------------------------------------------------------------------------}
+
+data Table k v blob = Table
+    { _values :: Map BS.ByteString (BS.ByteString, Maybe (BlobRef blob))
+    }
+
+type role Table nominal nominal nominal
+
+-- | An empty table.
+empty :: Table k v blob
+empty = Table Map.empty
+
+-- | This instance is for testing and debugging only.
+instance
+    ( SomeSerialisationConstraint k
+    , SomeSerialisationConstraint v
+    , SomeSerialisationConstraint blob
+    ) => IsList (Table k v blob)
+  where
+    type Item (Table k v blob) = (k, v, Maybe blob)
+    fromList xs = Table $ Map.fromList
+        [ (serialise k, (serialise v, mkBlobRef <$> mblob))
+        | (k, v, mblob) <- xs
+        ]
+
+    toList (Table m) =
+        [ (deserialise k, deserialise v, getBlobFromRef <$> mbref)
+        | (k, (v, mbref)) <- Map.toList m
+        ]
+
+-- | This instance is for testing and debugging only.
+instance Show (Table k v blob) where
+    showsPrec d (Table tbl) = showParen (d > 10)
+        $ showString "fromList "
+        . showsPrec 11 (toList (Table @BS.ByteString @BS.ByteString @BS.ByteString tbl'))
+      where
+        tbl' :: Map BS.ByteString (BS.ByteString, Maybe (BlobRef BS.ByteString))
+        tbl' = fmap (fmap (fmap coerceBlobRef)) tbl
+
+-- | This instance is for testing and debugging only.
+deriving instance Eq (Table k v blob)
+
+{-------------------------------------------------------------------------------
+  Table querying and updates
+-------------------------------------------------------------------------------}
+
+-- | Result of a single point lookup.
+data LookupResult k v blob =
+    NotFound      !k
+  | Found         !k !v
+  | FoundWithBlob !k !v !(BlobRef blob)
+  deriving (Eq, Show)
+
+-- Note: unfortunately we have to copy these types, as we need to implement BlobRef.
+
+
+-- | Perform a batch of lookups.
+--
+-- Lookups can be performed concurrently from multiple Haskell threads.
+lookups ::
+    (SomeSerialisationConstraint k, SomeSerialisationConstraint v)
+  => [k]
+  -> Table k v blob
+  -> [LookupResult k v blob]
+lookups ks tbl =
+    [ case Map.lookup (serialise k) (_values tbl) of
+        Nothing           -> NotFound k
+        Just (v, Nothing) -> Found k (deserialise v)
+        Just (v, Just br) -> FoundWithBlob k (deserialise v) br
+    | k <- ks
+    ]
+
+-- | A result for one point in a range lookup.
+data RangeLookupResult k v blob =
+    FoundInRange         !k !v
+  | FoundInRangeWithBlob !k !v !(BlobRef blob)
+  deriving (Eq, Show)
+
+-- | Perform a range lookup.
+--
+-- Range lookups can be performed concurrently from multiple Haskell threads.
+rangeLookup :: forall k v blob.
+     (SomeSerialisationConstraint k, SomeSerialisationConstraint v)
+  => Range k
+  -> Table k v blob
+  -> [RangeLookupResult k v blob]
+rangeLookup r tbl =
+    [ case v of
+        (v', Nothing) -> FoundInRange (deserialise k) (deserialise v')
+        (v', Just br) -> FoundInRangeWithBlob (deserialise k) (deserialise v') br
+    | let (ub, lb) = convertRange r
+    , (k, v) <- Map.R.rangeLookup lb ub (_values tbl)
+    ]
+  where
+    convertRange :: Range k -> (Map.R.Bound BS.ByteString, Map.R.Bound BS.ByteString)
+    convertRange (FromToExcluding lb ub) =
+        ( Map.R.Bound (serialise lb) Map.R.Inclusive
+        , Map.R.Bound (serialise ub) Map.R.Exclusive )
+    convertRange (FromToIncluding lb ub) =
+        ( Map.R.Bound (serialise lb) Map.R.Inclusive
+        , Map.R.Bound (serialise ub) Map.R.Inclusive )
+
+-- | Normal tables support insert and delete operations.
+--
+-- An __update__ is a term that groups all types of table-manipulating
+-- operations, like inserts and deletes.
+data Update v blob =
+    Insert !v !(Maybe blob)
+  | Delete
+  deriving (Eq, Show)
+
+-- | Perform a mixed batch of inserts and deletes.
+--
+-- Updates can be performed concurrently from multiple Haskell threads.
+updates :: forall k v blob.
+     ( SomeSerialisationConstraint k
+     , SomeSerialisationConstraint v
+     , SomeSerialisationConstraint blob
+     )
+  => [(k, Update v blob)]
+  -> Table k v blob
+  -> Table k v blob
+updates ups tbl0 = foldl' update tbl0 ups where
+    update :: Table k v blob -> (k, Update v blob) -> Table k v blob
+    update tbl (k, Delete) = tbl
+        { _values = Map.delete (serialise k) (_values tbl) }
+    update tbl (k, Insert v Nothing) = tbl
+        { _values = Map.insert (serialise k) (serialise v, Nothing) (_values tbl) }
+    update tbl (k, Insert v (Just blob)) = tbl
+        { _values = Map.insert (serialise k) (serialise v, Just (mkBlobRef blob)) (_values tbl)
+        }
+
+-- | Perform a batch of inserts.
+--
+-- Inserts can be performed concurrently from multiple Haskell threads.
+inserts ::
+     ( SomeSerialisationConstraint k
+     , SomeSerialisationConstraint v
+     , SomeSerialisationConstraint blob
+     )
+  => [(k, v, Maybe blob)]
+  -> Table k v blob
+  -> Table k v blob
+inserts = updates . fmap (\(k, v, blob) -> (k, Insert v blob))
+
+-- | Perform a batch of deletes.
+--
+-- Deletes can be performed concurrently from multiple Haskell threads.
+deletes ::
+     ( SomeSerialisationConstraint k
+     , SomeSerialisationConstraint v
+     , SomeSerialisationConstraint blob
+     )
+  => [k]
+  -> Table k v blob
+  -> Table k v blob
+deletes = updates . fmap (,Delete)
+
+-- | A reference to an on-disk blob.
+--
+-- The blob can be retrieved based on the reference.
+--
+-- Blob comes from the acronym __Binary Large OBject (BLOB)__ and in many
+-- database implementations refers to binary data that is larger than usual
+-- values and is handled specially. In our context we will allow optionally a
+-- blob associated with each value in the table.
+data BlobRef blob = BlobRef
+    !BS.ByteString  -- ^ digest
+    !BS.ByteString  -- ^ actual contents
+  deriving (Show)
+
+type role BlobRef nominal
+
+mkBlobRef :: SomeSerialisationConstraint blob => blob -> BlobRef blob
+mkBlobRef blob =  BlobRef (SHA256.hash bs) bs
+  where
+    !bs = serialise blob
+
+coerceBlobRef :: BlobRef blob -> BlobRef blob'
+coerceBlobRef (BlobRef d b) = BlobRef d b
+
+getBlobFromRef :: SomeSerialisationConstraint blob => BlobRef blob -> blob
+getBlobFromRef (BlobRef _ bs) = deserialise bs
+
+instance Eq (BlobRef blob) where
+    BlobRef x _ == BlobRef y _ = x == y
+
+-- | Perform a batch of blob retrievals.
+--
+-- This is a separate step from 'lookups' and 'rangeLookups. The result of a
+-- lookup can include a 'BlobRef', which can be used to retrieve the actual
+-- 'Blob'.
+--
+-- Blob lookups can be performed concurrently from multiple Haskell threads.
+retrieveBlobs ::
+     (SomeSerialisationConstraint blob)
+  => Table k v blob
+  -> [BlobRef blob]
+  -> [blob]
+retrieveBlobs _tbl refs = map getBlobFromRef refs
+
+{-------------------------------------------------------------------------------
+  Snapshots
+-------------------------------------------------------------------------------}
+
+snapshot ::
+     Table k v blob
+  -> Table k v blob
+snapshot = id
+
+{-------------------------------------------------------------------------------
+  Mutiple writable table handles
+-------------------------------------------------------------------------------}
+
+duplicate ::
+     Table k v blob
+  -> Table k v blob
+duplicate = id

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -27,7 +27,7 @@ module Database.LSMTree.Normal (
   , close
     -- * Table querying and updates
     -- ** Queries
-  , Range
+  , Range (..)
   , LookupResult (..)
   , lookups
   , RangeLookupResult (..)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,11 @@
 module Main (main) where
 
 import           Test.Database.LSMTree (tests)
+import qualified Test.Database.LSMTree.Model.Normal
 import           Test.Tasty
 
 main :: IO ()
-main = defaultMain tests
+main = defaultMain $ testGroup "lsm-tree"
+    [ tests
+    , Test.Database.LSMTree.Model.Normal.tests
+    ]

--- a/test/Test/Database/LSMTree/Model/Normal.hs
+++ b/test/Test/Database/LSMTree/Model/Normal.hs
@@ -1,0 +1,47 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Test.Database.LSMTree.Model.Normal (tests) where
+
+import qualified Data.ByteString as BS
+import           Database.LSMTree.Model.Normal
+import           GHC.Exts (IsList (..))
+import           Test.QuickCheck.Instances ()
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Model.Normal"
+    [ testProperty "lookup-insert" prop_lookupInsert
+    , testProperty "lookup-delete" prop_lookupDelete
+    , testProperty "insert-insert" prop_insertInsert
+    , testProperty "insert-commutes" prop_insertCommutes
+    ]
+
+type Key = BS.ByteString
+type Value = BS.ByteString
+type Blob = BS.ByteString
+
+type Tbl = Table Key Value Blob
+
+-- | You can lookup what you inserted.
+prop_lookupInsert :: Key -> Value -> Tbl -> Property
+prop_lookupInsert k v tbl =
+    lookups [k] (inserts [(k, v, Nothing)] tbl) === [Found k v]
+
+-- | You cannot lookup what you have deleted
+prop_lookupDelete :: Key -> Tbl -> Property
+prop_lookupDelete k tbl =
+    lookups [k] (deletes [k] tbl) === [NotFound k]
+
+-- | Last insert wins.
+prop_insertInsert :: Key -> Key -> Value -> Tbl -> Property
+prop_insertInsert k v1 v2 tbl =
+    inserts [(k, v1, Nothing), (k, v2, Nothing)] tbl === inserts [(k, v2, Nothing)] tbl
+
+-- | Different key inserts commute.
+prop_insertCommutes :: Key -> Value -> Key -> Value -> Tbl -> Property
+prop_insertCommutes k1 v1 k2 v2 tbl = k1 /= k2 ==>
+    inserts [(k1, v1, Nothing), (k2, v2, Nothing)] tbl === inserts [(k2, v2, Nothing), (k1, v1, Nothing)] tbl
+
+instance (SomeSerialisationConstraint k, SomeSerialisationConstraint v, SomeSerialisationConstraint blob, Arbitrary k, Arbitrary v, Arbitrary blob) => Arbitrary (Table k v blob) where
+    arbitrary = fromList <$> arbitrary
+    shrink t  = fromList <$> shrink (toList t)


### PR DESCRIPTION
Notes:
- Deserialisation must always succeed. Otherwise we'll need to add
  `Maybe`s and/or "deserialisation failed" constructors in return types.
  (`Maybe` could also be replaced with exceptions in IO interface, is
  that the plan?)
- Signature of `retrieveBlobs` doesnt' allow to return "NotFound".
  While it's true that BlobRefs are constructed by the library, so there
  can be an invariant that blobrefs are always valid,
  there *are no* mechanism to prevent trying retriving blob refs from a
  *wrong* table.
  In the model BlobRef always carries the original (serialised) data,
  so it cannot fail.
- The implementation adds few instances for testing purposes:
  - Eq, Show, IsList (Table k v blob)
  - Eq, Show on LookupResult etc. auxiliary types.