### PR TITLE
Model for lockstep tests

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -34,6 +34,7 @@ library
     Database.LSMTree.Common
     Database.LSMTree.Model.Monoidal
     Database.LSMTree.Model.Normal
+    Database.LSMTree.Model.Normal.Session
     Database.LSMTree.Monoidal
     Database.LSMTree.Normal
 
@@ -46,6 +47,7 @@ library
     , filepath
     , fs-api               ^>=0.2
     , io-classes           ^>=1.2
+    , mtl
     , strict-checked-vars  ^>=0.1.0.3
     , strict-mvar          ^>=1.2
     , strict-stm           ^>=1.2
@@ -68,10 +70,11 @@ test-suite lsm-tree-test
   build-depends:
     , base                  >=4.14 && <4.19
     , bytestring
+    , containers
     , deepseq
     , fs-api
-    , fs-sim                ^>=0.2
-    , io-sim                ^>=1.2
+    , fs-sim                >=0.2
+    , io-sim                >=1.2
     , lsm-tree
     , quickcheck-instances
     , tasty

--- a/src/Database/LSMTree/Common.hs
+++ b/src/Database/LSMTree/Common.hs
@@ -29,7 +29,7 @@ import           Data.Kind (Type)
 import           Data.Word (Word64)
 import qualified System.FilePath.Posix
 import qualified System.FilePath.Windows
-import           System.FS.API (FsPath, HasFS, SomeHasFS)
+import           System.FS.API (FsPath, SomeHasFS)
 
 {-------------------------------------------------------------------------------
   IOLike
@@ -62,7 +62,7 @@ data Session m = Session {
 
 newSession ::
      IOLike m
-  => HasFS m h
+  => SomeHasFS m
   -> FsPath -- ^ Path to an empty directory.
   -> m (Session m)
 newSession = undefined

--- a/src/Database/LSMTree/Model/Normal/Session.hs
+++ b/src/Database/LSMTree/Model/Normal/Session.hs
@@ -1,0 +1,385 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE EmptyDataDeriving          #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
+
+-- | Model a single session, allowing multiple tables.
+--
+-- Builds on top of "Database.LSMTree.Model.Normal", adding table handle and
+-- snapshot administration.
+module Database.LSMTree.Model.Normal.Session (
+    -- * Model
+    Model (..)
+  , initModel
+    -- ** Constraints
+  , C
+  , Model.SomeSerialisationConstraint (..)
+    -- ** ModelT and ModelM
+  , ModelT (..)
+  , runModelT
+  , ModelM
+  , runModelM
+    -- ** Errors
+  , Err (..)
+    -- * Tables
+  , TableHandle
+  , SUT.TableConfig (..)
+  , new
+  , close
+    -- * Table querying and updates
+    -- ** Queries
+  , Model.Range (..)
+  , Model.LookupResult (..)
+  , lookups
+  , Model.RangeLookupResult (..)
+  , rangeLookup
+    -- ** Updates
+  , Model.Update (..)
+  , updates
+  , inserts
+  , deletes
+    -- ** Blobs
+  , Model.BlobRef
+  , retrieveBlobs
+    -- * Snapshots
+  , SUT.SnapshotName
+  , snapshot
+  , open
+    -- * Multiple writable table handles
+  , duplicate
+  ) where
+
+import           Control.Monad (when)
+import           Control.Monad.Except (ExceptT (..), MonadError (..),
+                     runExceptT)
+import           Control.Monad.Identity (Identity (runIdentity))
+import           Control.Monad.State.Strict (MonadState (..), StateT (..), gets,
+                     modify)
+import           Data.Data (Typeable, cast)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Database.LSMTree.Model.Normal as Model
+import qualified Database.LSMTree.Normal as SUT
+import           Unsafe.Coerce (unsafeCoerce)
+
+{-------------------------------------------------------------------------------
+  Model
+-------------------------------------------------------------------------------}
+
+data Model = Model {
+    tableHandles      :: Map TableHandleID SomeTable
+  , nextTableHandleID :: TableHandleID
+  , snapshots         :: Map SUT.SnapshotName Snapshot
+  }
+  deriving Show
+
+initModel :: Model
+initModel = Model {
+      tableHandles = Map.empty
+    , nextTableHandleID = 0
+    , snapshots = Map.empty
+    }
+
+data SomeTable where
+  SomeTable :: forall k v blob. C k v blob
+            => Model.Table k v blob -> SomeTable
+
+instance Show SomeTable where
+  show (SomeTable table) = show table
+
+--
+-- Constraints
+--
+
+-- | Common constraints for keys, values and blobs
+type C k v blob = (
+    Show k, Show v, Show blob
+  , Eq k, Eq v, Eq blob
+  , Typeable k, Typeable v, Typeable blob
+  )
+
+--
+-- ModelT and ModelM
+--
+
+newtype ModelT m a = ModelT { _runModelT :: ExceptT Err (StateT Model m) a }
+  deriving stock Functor
+  deriving newtype ( Applicative
+                   , Monad
+                   , MonadState Model
+                   , MonadError Err
+                   )
+
+runModelT :: ModelT m a -> Model -> m (Either Err a, Model)
+runModelT = runStateT . runExceptT . _runModelT
+
+type ModelM = ModelT Identity
+
+runModelM :: ModelM a -> Model -> (Either Err a, Model)
+runModelM m = runIdentity . runModelT m
+
+--
+-- Errors
+--
+
+data Err =
+    ErrTableHandleClosed TableHandleID
+  | ErrSnapshotExists TableHandleID SUT.SnapshotName
+  | ErrSnapshotDoesNotExist SUT.SnapshotName
+  | ErrSnapshotWrongType SUT.SnapshotName
+  deriving (Show, Eq)
+
+{-------------------------------------------------------------------------------
+  Tables
+-------------------------------------------------------------------------------}
+
+type TableHandleID = Int
+
+--
+-- API
+--
+
+data TableHandle k v blob = TableHandle {
+    tableHandleID :: TableHandleID
+  , config        :: SUT.TableConfig
+  }
+  deriving Show
+
+new ::
+     forall k v blob m. (MonadState Model m, C k v blob)
+  => SUT.TableConfig
+  -> m (TableHandle k v blob)
+new config = state $ \Model{..} ->
+    let tableHandle = TableHandle {
+            tableHandleID = nextTableHandleID
+          , ..
+          }
+        someTable = SomeTable $ Model.empty @k @v @blob
+        tableHandles' = Map.insert nextTableHandleID someTable tableHandles
+        nextTableHandleID' = nextTableHandleID + 1
+        model' = Model {
+            tableHandles = tableHandles'
+          , nextTableHandleID = nextTableHandleID'
+          , ..
+          }
+    in  (tableHandle, model')
+
+-- |
+--
+-- This is idempotent.
+close :: MonadState Model m => TableHandle k v blob -> m ()
+close TableHandle{..} = state $ \Model{..} ->
+    let tableHandles' = Map.delete tableHandleID tableHandles
+        model' = Model {
+            tableHandles = tableHandles'
+          , nextTableHandleID
+          , ..
+          }
+    in ((), model')
+
+--
+-- Utility
+--
+
+guardTableHandleIsOpen ::
+     forall k v blob m. (MonadState Model m, MonadError Err m)
+  => TableHandle k v blob
+  -> m (Model.Table k v blob)
+guardTableHandleIsOpen TableHandle{..} =
+    gets (Map.lookup tableHandleID . tableHandles) >>= \case
+      Nothing ->
+        throwError $ ErrTableHandleClosed tableHandleID
+      Just table ->
+        pure $ unsafeCoerce table
+
+newTableWith ::
+     (MonadState Model m, C k v blob)
+  => SUT.TableConfig
+  -> Model.Table k v blob
+  -> m (TableHandle k v blob)
+newTableWith config tbl = state $ \Model{..} ->
+  let tableHandle = TableHandle {
+          tableHandleID = nextTableHandleID
+        , config
+        }
+      someTable = SomeTable tbl
+      tableHandles' = Map.insert nextTableHandleID someTable tableHandles
+      nextTableHandleID' = nextTableHandleID + 1
+      model' = Model {
+          tableHandles = tableHandles'
+        , nextTableHandleID = nextTableHandleID'
+        , ..
+        }
+  in  (tableHandle, model')
+
+{-------------------------------------------------------------------------------
+  Table querying and updates
+-------------------------------------------------------------------------------}
+
+--
+-- API
+--
+
+lookups ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint k
+     , Model.SomeSerialisationConstraint v
+     )
+  => [k]
+  -> TableHandle k v blob
+  -> m [Model.LookupResult k v (Model.BlobRef blob)]
+lookups ks th = do
+    table <- guardTableHandleIsOpen th
+    pure $ Model.lookups ks table
+
+type RangeLookupResult k v blobref = Model.RangeLookupResult k v blobref
+
+rangeLookup ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint k
+     , Model.SomeSerialisationConstraint v
+     )
+  => Model.Range k
+  -> TableHandle k v blob
+  -> m [RangeLookupResult k v (Model.BlobRef blob)]
+rangeLookup r th = do
+    table <- guardTableHandleIsOpen th
+    pure $ Model.rangeLookup r table
+
+updates ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint k
+     , Model.SomeSerialisationConstraint v
+     , Model.SomeSerialisationConstraint blob
+     , C k v blob
+     )
+  => [(k, Model.Update v blob)]
+  -> TableHandle k v blob
+  -> m ()
+updates ups th@TableHandle{..} = do
+  table <- guardTableHandleIsOpen th
+  let table' = Model.updates ups table
+  modify (\m -> m {
+      tableHandles = Map.insert tableHandleID (SomeTable table') (tableHandles m)
+    })
+
+inserts ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint k
+     , Model.SomeSerialisationConstraint v
+     , Model.SomeSerialisationConstraint blob
+     , C k v blob
+     )
+  => [(k, v, Maybe blob)]
+  -> TableHandle k v blob
+  -> m ()
+inserts = updates . fmap (\(k, v, blob) -> (k, Model.Insert v blob))
+
+deletes ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint k
+     , Model.SomeSerialisationConstraint v
+     , Model.SomeSerialisationConstraint blob
+     , C k v blob
+     )
+  => [k]
+  -> TableHandle k v blob
+  -> m ()
+deletes = updates . fmap (,Model.Delete)
+
+retrieveBlobs ::
+     ( MonadState Model m
+     , MonadError Err m
+     , Model.SomeSerialisationConstraint blob
+     )
+  => TableHandle k v blob
+  -> [Model.BlobRef blob]
+  -> m [blob]
+retrieveBlobs th refs = do
+    table <- guardTableHandleIsOpen th
+    pure $ Model.retrieveBlobs table refs
+
+{-------------------------------------------------------------------------------
+  Snapshots
+-------------------------------------------------------------------------------}
+
+data Snapshot = Snapshot SUT.TableConfig SomeTable
+  deriving Show
+
+--
+-- API
+--
+
+snapshot ::
+     ( MonadState Model m
+     , MonadError Err m
+     , C k v blob
+     )
+  => SUT.SnapshotName
+  -> TableHandle k v blob
+  -> m ()
+snapshot name th@TableHandle{..} = do
+    table <- guardTableHandleIsOpen th
+    snaps <- gets snapshots
+    when (Map.member name snaps) $
+      throwError (ErrSnapshotExists tableHandleID name)
+    modify (\m -> m {
+        snapshots = Map.insert name (Snapshot config $ SomeTable $ Model.snapshot table) (snapshots m)
+      })
+
+open ::
+     forall k v blob m.(
+       MonadState Model m
+     , MonadError Err m
+     , C k v blob
+     )
+  => SUT.SnapshotName
+  -> m (TableHandle k v blob)
+open name = do
+    snaps <- gets snapshots
+    case Map.lookup name snaps of
+      Nothing ->
+        throwError (ErrSnapshotDoesNotExist name)
+      Just (Snapshot conf (SomeTable (table :: Model.Table k' v' blob'))) ->
+        case cast @(Model.Table k' v' blob') @(Model.Table k v blob) table of
+          Nothing ->
+            throwError $ ErrSnapshotWrongType name
+          Just table' ->
+            newTableWith conf table'
+
+{-------------------------------------------------------------------------------
+  Mutiple writable table handles
+-------------------------------------------------------------------------------}
+
+--
+-- API
+--
+
+duplicate ::
+     ( MonadState Model m
+     , MonadError Err m
+     , C k v blob
+     )
+  => TableHandle k v blob
+  -> m (TableHandle k v blob)
+duplicate th@TableHandle{..} = do
+    table <- guardTableHandleIsOpen th
+    newTableWith config $ Model.duplicate table
+
+-- TODO: listing snapshots, and deleting snapshots

--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -22,7 +22,7 @@ module Database.LSMTree.Monoidal (
   , closeSession
     -- * Tables
   , TableHandle
-  , TableConfig
+  , TableConfig (..)
   , new
   , close
     -- * Table querying and updates
@@ -39,7 +39,6 @@ module Database.LSMTree.Monoidal (
   , deletes
   , mupserts
     -- * Snapshots
-  , VerificationFailure
   , SnapshotName
   , snapshot
   , open
@@ -94,6 +93,7 @@ data TableConfig = TableConfig {
 --
 -- For more information about compatibility, see 'Session'.
 deriving instance Eq TableConfig
+deriving instance Show TableConfig
 
 -- | Create a new table referenced by a table handle.
 --
@@ -169,6 +169,7 @@ data Update v =
   | Delete
     -- | TODO: should be given a more suitable name.
   | Mupsert !v
+  deriving (Show, Eq)
 
 -- | Perform a mixed batch of inserts, deletes and monoidal upserts.
 --
@@ -230,8 +231,6 @@ mupserts = updates . fmap (second Mupsert)
   Snapshots
 -------------------------------------------------------------------------------}
 
-data VerificationFailure
-
 -- | Take a snapshot.
 --
 -- Snapshotting does not close the table handle.
@@ -266,10 +265,7 @@ open ::
      )
   => Session m
   -> SnapshotName
-  -> m (Either
-          VerificationFailure
-          (TableHandle m k v)
-       )
+  -> m (TableHandle m k v)
 open = undefined
 
 {-------------------------------------------------------------------------------
@@ -293,7 +289,6 @@ duplicate ::
   => TableHandle m k v
   -> m (TableHandle m k v)
 duplicate = undefined
-
 
 {-------------------------------------------------------------------------------
   Merging tables

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -22,7 +22,7 @@ module Database.LSMTree.Normal (
   , closeSession
     -- * Tables
   , TableHandle
-  , TableConfig
+  , TableConfig (..)
   , new
   , close
     -- * Table querying and updates
@@ -41,7 +41,6 @@ module Database.LSMTree.Normal (
   , BlobRef
   , retrieveBlobs
     -- * Snapshots
-  , VerificationFailure
   , SnapshotName
   , snapshot
   , open
@@ -93,6 +92,7 @@ data TableConfig = TableConfig {
 --
 -- For more information about compatibility, see 'Session'.
 deriving instance Eq TableConfig
+deriving instance Show TableConfig
 
 -- | Create a new table referenced by a table handle.
 --
@@ -160,6 +160,7 @@ rangeLookup = undefined
 data Update v blob =
     Insert !v !(Maybe blob)
   | Delete
+  deriving (Show, Eq)
 
 -- | Perform a mixed batch of inserts and deletes.
 --
@@ -211,7 +212,7 @@ deletes = updates . fmap (,Delete)
 -- database implementations refers to binary data that is larger than usual
 -- values and is handled specially. In our context we will allow optionally a
 -- blob associated with each value in the table.
-data BlobRef blob
+data BlobRef blob = BlobRef
 
 -- | Perform a batch of blob retrievals.
 --
@@ -230,8 +231,6 @@ retrieveBlobs = undefined
 {-------------------------------------------------------------------------------
   Snapshots
 -------------------------------------------------------------------------------}
-
-data VerificationFailure
 
 -- | Take a snapshot.
 --
@@ -269,10 +268,7 @@ open ::
      )
   => Session m
   -> SnapshotName
-  -> m (Either
-          VerificationFailure
-          (TableHandle m k v blob)
-       )
+  -> m (TableHandle m k v blob)
 open = undefined
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Adds a model that does snapshot/table handle administration within a single session. It is built on top of `Database.LSMTree.Model.Normal`. 

Also includes some small changes to the `Normal` and `Monoidal` APIs.