### PR TITLE
Remove session argument from `snapshot`

### DIFF
--- a/src/Database/LSMTree/Monoidal.hs
+++ b/src/Database/LSMTree/Monoidal.hs
@@ -248,8 +248,7 @@ snapshot ::
      , SomeSerialisationConstraint k
      , SomeSerialisationConstraint v
      )
-  => Session m
-  -> SnapshotName
+  => SnapshotName
   -> TableHandle m k v
   -> m ()
 snapshot = undefined

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -354,8 +354,7 @@ snapshot ::
      , SomeSerialisationConstraint v
      , SomeSerialisationConstraint blob
      )
-  => Session m
-  -> SnapshotName
+  => SnapshotName
   -> TableHandle m k v blob
   -> m ()
 snapshot = undefined

--- a/test/Test/Database/LSMTree/Normal/StateMachine.hs
+++ b/test/Test/Database/LSMTree/Normal/StateMachine.hs
@@ -454,7 +454,7 @@ runIO action lookUp = ReaderT $ \session -> aux session action
         RetrieveBlobs tableVar blobRefsVar -> catchErr $
           fmap Wrap <$> SUT.retrieveBlobs (lookUp' tableVar) (lookUp' blobRefsVar)
         Snapshot name tableVar -> catchErr $
-          SUT.snapshot session name (lookUp' tableVar)
+          SUT.snapshot name (lookUp' tableVar)
         Open name -> catchErr $
           SUT.open session name
         Duplicate tableVar -> catchErr $
@@ -488,7 +488,7 @@ runIOSim action lookUp = ReaderT $ \session -> aux session action
         RetrieveBlobs tableVar blobRefsVar -> catchErr $
           fmap Wrap <$> SUT.retrieveBlobs (lookUp' tableVar) (lookUp' blobRefsVar)
         Snapshot name tableVar -> catchErr $
-          SUT.snapshot session name (lookUp' tableVar)
+          SUT.snapshot name (lookUp' tableVar)
         Open name -> catchErr $
           SUT.open session name
         Duplicate tableVar -> catchErr $


### PR DESCRIPTION
The table handle should already know its session,
and not having to duplicate the information will only help the code to be correct, as you wouldn't be able to try to snapshot table handle in the wrong session.