### PR TITLE
Monoidal IO model

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -60,6 +60,7 @@ test-suite lsm-tree-test
     Database.LSMTree.Model.Monoidal
     Database.LSMTree.Model.Normal
     Database.LSMTree.Model.Normal.Session
+    Database.LSMTree.ModelIO.Monoidal
     Database.LSMTree.ModelIO.Normal
     Database.LSMTree.ModelIO.Session
     Test.Database.LSMTree
@@ -67,6 +68,8 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Model.Monoidal
     Test.Database.LSMTree.Model.Normal
     Test.Database.LSMTree.ModelIO.Class
+    Test.Database.LSMTree.ModelIO.Monoidal
+    Test.Database.LSMTree.ModelIO.Monoidal.Class
     Test.Database.LSMTree.ModelIO.Normal
     Test.Database.LSMTree.Normal.StateMachine
     Test.Database.LSMTree.Normal.StateMachine.Op

--- a/test/Database/LSMTree/Model/Monoidal.hs
+++ b/test/Database/LSMTree/Model/Monoidal.hs
@@ -130,7 +130,7 @@ rangeLookup :: forall k v.
   -> [RangeLookupResult k v]
 rangeLookup r tbl =
     [ FoundInRange (deserialise k) (deserialise v)
-    | let (ub, lb) = convertRange r
+    | let (lb, ub) = convertRange r
     , (k, v) <- Map.R.rangeLookup lb ub (_values tbl)
     ]
   where

--- a/test/Database/LSMTree/ModelIO/Session.hs
+++ b/test/Database/LSMTree/ModelIO/Session.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds          #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE QuantifiedConstraints    #-}
 {-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE StandaloneDeriving       #-}

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import qualified Test.Database.LSMTree
 import qualified Test.Database.LSMTree.Common
 import qualified Test.Database.LSMTree.Model.Monoidal
 import qualified Test.Database.LSMTree.Model.Normal
+import qualified Test.Database.LSMTree.ModelIO.Monoidal
 import qualified Test.Database.LSMTree.ModelIO.Normal
 import qualified Test.Database.LSMTree.Normal.StateMachine
 import           Test.Tasty
@@ -15,5 +16,6 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Model.Normal.tests
     , Test.Database.LSMTree.Model.Monoidal.tests
     , Test.Database.LSMTree.ModelIO.Normal.tests
+    , Test.Database.LSMTree.ModelIO.Monoidal.tests
     , Test.Database.LSMTree.Normal.StateMachine.tests
     ]

--- a/test/Test/Database/LSMTree/ModelIO/Class.hs
+++ b/test/Test/Database/LSMTree/ModelIO/Class.hs
@@ -139,8 +139,8 @@ class (IsSession (Session h)) => IsTableHandle h where
 
 instance IsSession M.Session where
     newSession = M.newSession
-    deleteSnapshot = undefined -- TODO
-    listSnapshots = undefined -- TODO
+    deleteSnapshot = M.deleteSnapshot
+    listSnapshots = M.listSnapshots
 
 instance IsTableHandle M.TableHandle where
     type Session M.TableHandle = M.Session

--- a/test/Test/Database/LSMTree/ModelIO/Monoidal.hs
+++ b/test/Test/Database/LSMTree/ModelIO/Monoidal.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+module Test.Database.LSMTree.ModelIO.Monoidal (tests) where
+
+import qualified Data.ByteString as BS
+import           Data.List (sortOn)
+import           Data.Maybe (fromMaybe)
+import           Data.Proxy (Proxy (..))
+import           Data.Word (Word64)
+import           Database.LSMTree.Common (mkSnapshotName)
+import           Database.LSMTree.ModelIO.Monoidal (LookupResult (..),
+                     Range (..), RangeLookupResult (..), TableHandle,
+                     Update (..))
+import           Test.Database.LSMTree.ModelIO.Monoidal.Class
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans ()
+
+tests :: TestTree
+tests = testGroup "Database.LSMTree.ModelIO.Monoidal"
+    [ testProperty "lookup-insert" $ prop_lookupInsert tbl
+    , testProperty "lookup-insert-else" $ prop_lookupInsertElse tbl
+    , testProperty "lookup-delete" $ prop_lookupDelete tbl
+    , testProperty "lookup-delete-else" $ prop_lookupDeleteElse tbl
+    , testProperty "insert-insert" $ prop_insertInsert tbl
+    , testProperty "insert-commutes" $ prop_insertCommutes tbl
+    , testProperty "dup-insert-insert" $ prop_dupInsertInsert tbl
+    , testProperty "dup-insert-comm" $ prop_dupInsertCommutes tbl
+    , testProperty "dup-nochanges" $ prop_dupNoChanges tbl
+    , testProperty "lookupRange-insert" $ prop_insertLookupRange tbl
+    , testProperty "snapshot-nochanges" $ prop_snapshotNoChanges tbl
+    , testProperty "snapshot-nochanges2" $ prop_snapshotNoChanges2 tbl
+    ]
+  where
+    tbl = Proxy :: Proxy TableHandle
+
+-------------------------------------------------------------------------------
+-- test setup and helpers
+-------------------------------------------------------------------------------
+
+type Key = Word64
+type Value = BS.ByteString
+
+makeNewTable :: forall h. IsTableHandle h => Proxy h
+    -> [(Key, Update Value)]
+    -> IO (Session h IO, h IO Key Value)
+makeNewTable h ups = do
+    s <- newSession
+    hdl <- new @h s (testTableConfig h)
+    updates hdl ups
+    return (s, hdl)
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for basic k/v properties
+-------------------------------------------------------------------------------
+
+-- | You can lookup what you inserted.
+prop_lookupInsert ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key  -> Value -> Property
+prop_lookupInsert h ups k v = ioProperty $ do
+    -- create session, table handle, and populate it with some data.
+    (_, hdl) <- makeNewTable h ups
+
+    -- the main dish
+    inserts hdl [(k, v)]
+    res <- lookups hdl [k]
+
+    return $ res === [Found k v]
+
+-- | Insert doesn't change the lookup results of other keys.
+prop_lookupInsertElse ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key  -> Value -> [Key] -> Property
+prop_lookupInsertElse h ups k v testKeys = ioProperty $ do
+    -- create session, table handle, and populate it with some data.
+    (_, hdl) <- makeNewTable h ups
+
+    let testKeys' = filter (/= k) testKeys
+    res1 <- lookups hdl testKeys'
+    inserts hdl [(k, v)]
+    res2 <-  lookups hdl testKeys'
+
+    return $ res1 === res2
+
+-- | You cannot lookup what you have just deleted
+prop_lookupDelete ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key -> Property
+prop_lookupDelete h ups k = ioProperty $ do
+    (_, hdl) <- makeNewTable h ups
+    deletes hdl [k]
+    res <- lookups hdl [k]
+    return $ res === [NotFound k]
+
+-- | Delete doesn't change the lookup results of other keys
+prop_lookupDeleteElse ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key  -> [Key] -> Property
+prop_lookupDeleteElse h ups k testKeys = ioProperty $ do
+    -- create session, table handle, and populate it with some data.
+    (_, hdl) <- makeNewTable h ups
+
+    let testKeys' = filter (/= k) testKeys
+    res1 <- lookups hdl testKeys'
+    deletes hdl [k]
+    res2 <-  lookups hdl testKeys'
+
+    return $ res1 === res2
+
+-- | Last insert wins.
+prop_insertInsert ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key -> Value -> Value -> Property
+prop_insertInsert h ups k v1 v2 = ioProperty $ do
+    (_, hdl) <- makeNewTable h ups
+    inserts hdl [(k, v1), (k, v2)]
+    res <- lookups hdl [k]
+    return $ res === [Found k v2]
+
+-- | Inserts with different keys don't interfere.
+prop_insertCommutes ::
+       IsTableHandle h
+    => Proxy h -> [(Key, Update Value)]
+    -> Key -> Value -> Key -> Value -> Property
+prop_insertCommutes h ups k1 v1 k2 v2 = k1 /= k2 ==> ioProperty do
+    (_, hdl) <- makeNewTable h ups
+    inserts hdl [(k1, v1), (k2, v2)]
+
+    res <- lookups hdl [k1,k2]
+    return $ res === [Found k1 v1, Found k2 v2]
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for range lookups
+-------------------------------------------------------------------------------
+
+evalRange :: Ord k => Range k -> k -> Bool
+evalRange (FromToExcluding lo hi) x = lo <= x && x < hi
+evalRange (FromToIncluding lo hi) x = lo <= x && x <= hi
+
+rangeLookupResultKey :: RangeLookupResult k v -> k
+rangeLookupResultKey (FoundInRange k _)             = k
+
+-- | Last insert wins.
+prop_insertLookupRange ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key -> Value -> Range Key  -> Property
+prop_insertLookupRange h ups k v r = ioProperty $ do
+    (_, hdl) <- makeNewTable h ups
+
+    res <- rangeLookup hdl r
+
+    inserts hdl [(k, v)]
+
+    res' <- rangeLookup hdl r
+
+    let p :: RangeLookupResult Key Value -> Bool
+        p rlr = rangeLookupResultKey rlr /= k
+
+    if evalRange r k
+    then return $ sortOn rangeLookupResultKey (FoundInRange k v : filter p res) === res'
+    else return $ res === res'
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for split-value BLOB retrieval
+-------------------------------------------------------------------------------
+
+{- not applicable -}
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for monoidal updates
+-------------------------------------------------------------------------------
+
+{- TODO -}
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for monoidal table merges
+-------------------------------------------------------------------------------
+
+{- TODO -}
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for snapshots
+-------------------------------------------------------------------------------
+
+-- changes to handle would not change the snapshot
+prop_snapshotNoChanges :: forall h.
+     IsTableHandle h
+    => Proxy h -> [(Key, Update Value)]
+    -> [(Key, Update Value)] -> [Key] -> Property
+prop_snapshotNoChanges h ups ups' testKeys = ioProperty $ do
+    (sess, hdl1) <- makeNewTable h ups
+
+    res <- lookups hdl1 testKeys
+
+    let name = fromMaybe (error "invalid name") $ mkSnapshotName "foo"
+
+    snapshot name hdl1
+    updates hdl1 ups'
+
+    hdl2 <- open @h sess name
+
+    res' <- lookups hdl2 testKeys
+
+    return $ res == res'
+
+-- same snapshot may be opened multiple times,
+-- and the handles are separate.
+prop_snapshotNoChanges2 :: forall h.
+     IsTableHandle h
+    => Proxy h -> [(Key, Update Value)]
+    -> [(Key, Update Value)] -> [Key] -> Property
+prop_snapshotNoChanges2 h ups ups' testKeys = ioProperty $ do
+    (sess, hdl0) <- makeNewTable h ups
+    let name = fromMaybe (error "invalid name") $ mkSnapshotName "foo"
+    snapshot name hdl0
+
+    hdl1 <- open @h sess name
+    hdl2 <- open @h sess name
+
+    res <- lookups hdl1 testKeys
+    updates hdl1 ups'
+    res' <- lookups hdl2 testKeys
+
+    return $ res == res'
+
+-------------------------------------------------------------------------------
+-- implement classic QC tests for multiple writable table handles
+--  - results of insert/delete, monoidal update, lookups, and range lookups should
+--    be equal if applied to two duplicated table handles
+--  - changes to one handle should not cause any visible changes in any others
+-------------------------------------------------------------------------------
+
+-- | Last insert wins.
+prop_dupInsertInsert ::
+     IsTableHandle h
+  => Proxy h -> [(Key, Update Value)]
+  -> Key -> Value -> Value -> [Key] -> Property
+prop_dupInsertInsert h ups k v1 v2 testKeys = ioProperty $ do
+    (_, hdl1) <- makeNewTable h ups
+    hdl2 <- duplicate hdl1
+
+    inserts hdl1 [(k, v1), (k, v2)]
+    inserts hdl2 [(k, v2)]
+
+    res1 <- lookups hdl1 testKeys
+    res2 <- lookups hdl2 testKeys
+    return $ res1 === res2
+
+-- | Different key inserts commute.
+prop_dupInsertCommutes ::
+     IsTableHandle h
+    => Proxy h -> [(Key, Update Value)]
+    -> Key -> Value -> Key -> Value -> [Key] -> Property
+prop_dupInsertCommutes h ups k1 v1 k2 v2 testKeys = k1 /= k2 ==> ioProperty do
+    (_, hdl1) <- makeNewTable h ups
+    hdl2 <- duplicate hdl1
+
+    inserts hdl1 [(k1, v1), (k2, v2)]
+    inserts hdl2 [(k2, v2), (k1, v1)]
+
+    res1 <- lookups hdl1 testKeys
+    res2 <- lookups hdl2 testKeys
+    return $ res1 === res2
+
+-- changes to one handle should not cause any visible changes in any others
+prop_dupNoChanges ::
+     IsTableHandle h
+    => Proxy h -> [(Key, Update Value)]
+    -> [(Key, Update Value)] -> [Key] -> Property
+prop_dupNoChanges h ups ups' testKeys = ioProperty $ do
+    (_, hdl1) <- makeNewTable h ups
+
+    res <- lookups hdl1 testKeys
+
+    hdl2 <- duplicate hdl1
+    updates hdl2 ups'
+
+    -- lookup hdl1 again.
+    res' <- lookups hdl1 testKeys
+
+    return $ res == res'
+

--- a/test/Test/Database/LSMTree/ModelIO/Monoidal/Class.hs
+++ b/test/Test/Database/LSMTree/ModelIO/Monoidal/Class.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE KindSignatures           #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE QuantifiedConstraints    #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeFamilies             #-}
+module Test.Database.LSMTree.ModelIO.Monoidal.Class (
+    IsSession (..)
+  , IsTableHandle (..)
+  ) where
+
+import           Data.Kind (Constraint, Type)
+import           Data.Proxy (Proxy)
+import           Data.Typeable (Typeable)
+import           Database.LSMTree.Common (IOLike, Range (..), SnapshotName,
+                     SomeSerialisationConstraint, SomeUpdateConstraint)
+import qualified Database.LSMTree.ModelIO.Monoidal as M
+import           Database.LSMTree.Monoidal (LookupResult (..),
+                     RangeLookupResult (..), Update (..))
+import qualified Database.LSMTree.Monoidal as R
+import           Test.Database.LSMTree.ModelIO.Class (IsSession (..))
+
+
+-- | Class abstracting over table handle operations.
+--
+type IsTableHandle :: ((Type -> Type) -> Type -> Type -> Type) -> Constraint
+class (IsSession (Session h)) => IsTableHandle h where
+    type Session h :: (Type -> Type) -> Type
+    type TableConfig h :: Type
+
+    testTableConfig :: Proxy h -> TableConfig h
+
+    new ::
+           IOLike m
+        => Session h m
+        -> TableConfig h
+        -> m (h m k v)
+
+    close ::
+           IOLike m
+        => h m k v
+        -> m ()
+
+    lookups ::
+            (IOLike m, SomeSerialisationConstraint k, SomeSerialisationConstraint v, SomeUpdateConstraint v)
+        => h m k v
+        -> [k]
+        -> m [LookupResult k v]
+
+    rangeLookup ::
+            (IOLike m, SomeSerialisationConstraint k, SomeSerialisationConstraint v, SomeUpdateConstraint v)
+        => h m k v
+        -> Range k
+        -> m [RangeLookupResult k v]
+
+    updates ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+        , SomeUpdateConstraint v
+        )
+        => h m k v
+        -> [(k, Update v)]
+        -> m ()
+
+    inserts ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+        , SomeUpdateConstraint v
+        )
+        => h m k v
+        -> [(k, v)]
+        -> m ()
+
+    deletes ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+        , SomeUpdateConstraint v
+        )
+        => h m k v
+        -> [k]
+        -> m ()
+
+    mupserts ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+        , SomeUpdateConstraint v
+        )
+        => h m k v
+        -> [(k, v)]
+        -> m ()
+
+    snapshot ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+          -- Model-specific constraints
+        , Typeable k
+        , Typeable v
+        )
+        => SnapshotName
+        -> h m k v
+        -> m ()
+
+    open ::
+        ( IOLike m
+        , SomeSerialisationConstraint k
+        , SomeSerialisationConstraint v
+          -- Model-specific constraints
+        , Typeable k
+        , Typeable v
+        )
+        => Session h m
+        -> SnapshotName
+        -> m (h m k v)
+
+    duplicate ::
+            IOLike m
+        => h m k v
+        -> m (h m k v)
+
+    mergeTables ::
+        (IOLike m, SomeSerialisationConstraint v, SomeUpdateConstraint v)
+        => h m k v
+        -> h m k v
+        -> m (h m k v)
+
+instance IsTableHandle M.TableHandle where
+    type Session M.TableHandle = M.Session
+    type TableConfig M.TableHandle = M.TableConfig
+
+    testTableConfig _ = M.TableConfig
+
+    new = M.new
+    close = M.close
+    lookups = flip M.lookups
+    updates = flip M.updates
+    inserts = flip M.inserts
+    deletes = flip M.deletes
+    mupserts = flip M.mupserts
+
+    rangeLookup = flip M.rangeLookup
+
+    snapshot = M.snapshot
+    open = M.open
+
+    duplicate = M.duplicate
+    mergeTables = M.mergeTables
+
+instance IsTableHandle R.TableHandle where
+    type Session R.TableHandle = R.Session
+    type TableConfig R.TableHandle = R.TableConfig
+
+    testTableConfig _ = error "TODO: test TableConfig"
+
+    new = R.new
+    close = R.close
+    lookups = flip R.lookups
+    updates = flip R.updates
+    inserts = flip R.inserts
+    deletes = flip R.deletes
+    mupserts = flip R.mupserts
+
+    rangeLookup = flip R.rangeLookup
+
+    snapshot = R.snapshot
+    open = R.open
+
+    duplicate = R.duplicate
+    mergeTables = R.mergeTables


### PR DESCRIPTION
Builds on top of #26  and #27.

First commit (Copy&paste&tweak ...) is straight-forward.
Second commit adds monoidal specific tests (mupdate and mergeTables)