### PR TITLE
Match ModelIO model with pure model in statemachine tests

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -76,6 +76,7 @@ test-suite lsm-tree-test
   build-depends:
     , base                  >=4.14 && <4.19
     , bytestring
+    , constraints
     , containers
     , cryptohash-sha256
     , deepseq

--- a/src/Database/LSMTree/Normal.hs
+++ b/src/Database/LSMTree/Normal.hs
@@ -315,6 +315,8 @@ data BlobRef blob = BlobRef
 -- 'Blob'.
 --
 -- Blob lookups can be performed concurrently from multiple Haskell threads.
+--
+-- TODO: remove table handle argument
 retrieveBlobs ::
      (IOLike m, SomeSerialisationConstraint blob)
   => TableHandle m k v blob

--- a/test/Database/LSMTree/ModelIO/Normal.hs
+++ b/test/Database/LSMTree/ModelIO/Normal.hs
@@ -70,6 +70,7 @@ import           Database.LSMTree.ModelIO.Session
 import           Database.LSMTree.Normal (LookupResult (..),
                      RangeLookupResult (..), Update (..))
 import           GHC.IO.Exception (IOErrorType (..), IOException (..))
+import           System.IO.Error (alreadyExistsErrorType)
 
 {-------------------------------------------------------------------------------
   Tables
@@ -201,8 +202,19 @@ snapshot ::
   -> TableHandle m k v blob
   -> m ()
 snapshot n TableHandle {..} = atomically $
-    withModel "snapshot" thSession thRef $ \tbl ->
-        modifyTVar' (snapshots thSession) (Map.insert n (toDyn tbl))
+    withModel "snapshot" thSession thRef $ \tbl -> do
+        snaps <- readTVar $ snapshots thSession
+        if Map.member n snaps then
+          throwSTM IOError
+            { ioe_handle      = Nothing
+            , ioe_type        = alreadyExistsErrorType
+            , ioe_location    = "snapshot"
+            , ioe_description = "snapshot already exists"
+            , ioe_errno       = Nothing
+            , ioe_filename    = Nothing
+            }
+        else
+          modifyTVar' (snapshots thSession) (Map.insert n (toDyn tbl))
 
 -- | Open a table through a snapshot, returning a new table handle.
 open ::


### PR DESCRIPTION
Other, somewhat related changes:
* Add some TODOs in code
* Generate statemachine actions for two distinct key-value-blob types instead of just one, which should trigger more interesting error cases
* Add `showRealResponse` implementations