### PR TITLE
Separate module for QuickCheck generators

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -65,13 +65,16 @@ library lsm-tree-utils
   default-language: Haskell2010
   exposed-modules:
     Database.LSMTree.Extras
+    Database.LSMTree.Generators
     System.Random.Extras
 
   build-depends:
     , base
     , bloomfilter
     , containers
+    , deepseq
     , lsm-tree
+    , QuickCheck
     , random
 
 test-suite lsm-tree-test
@@ -88,6 +91,7 @@ test-suite lsm-tree-test
     Database.LSMTree.ModelIO.Normal
     Database.LSMTree.ModelIO.Session
     Test.Database.LSMTree.Common
+    Test.Database.LSMTree.Generators
     Test.Database.LSMTree.Internal.Run.BloomFilter
     Test.Database.LSMTree.Internal.Run.Index.Compact
     Test.Database.LSMTree.Model.Monoidal

--- a/src/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/src/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -263,8 +263,8 @@ data MCompactIndex s k = MCompactIndex {
 -- | One-shot construction.
 --
 fromList :: (SliceBits k, Integral k) => Int -> [(k, k)] -> CompactIndex k
-fromList tb ks = runST $ do
-    mci <- new tb n
+fromList rfprec ks = runST $ do
+    mci <- new rfprec n
     mapM_ (`append` mci) ks
     unsafeFreeze mci
   where

--- a/src/utils/Database/LSMTree/Generators.hs
+++ b/src/utils/Database/LSMTree/Generators.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+
+module Database.LSMTree.Generators (
+    -- * Range-finder precision
+    RFPrecision (..)
+  , rfprecInvariant
+    -- * Pages (non-partitioned)
+  , Pages (..)
+  , mkPages
+  , pagesInvariant
+    -- * Pages (partitioned)
+  , PartitionedPages (..)
+  , mkPartitionedPages
+  , partitionedPagesInvariant
+  ) where
+
+import           Control.DeepSeq (NFData)
+import           Data.List (sort)
+import           Database.LSMTree.Internal.Run.Index.Compact (SliceBits,
+                     rangeFinderPrecisionBounds, topBits16)
+import           GHC.Generics (Generic)
+
+import           Data.Containers.ListUtils
+import           Test.QuickCheck (Arbitrary (..), scale, suchThat)
+
+{-------------------------------------------------------------------------------
+  Range-finder precision
+-------------------------------------------------------------------------------}
+
+newtype RFPrecision = RFPrecision Int
+  deriving stock (Show, Eq, Ord)
+  deriving newtype (NFData, Num)
+
+instance Arbitrary RFPrecision where
+  arbitrary = (RFPrecision <$> arbitrary) `suchThat` rfprecInvariant
+  shrink (RFPrecision x) = [RFPrecision x' | x' <- shrink x
+                                           , rfprecInvariant (RFPrecision x')
+                                           ]
+
+rfprecInvariant :: RFPrecision -> Bool
+rfprecInvariant (RFPrecision x) =
+       x >= fst rangeFinderPrecisionBounds
+    && x <= snd rangeFinderPrecisionBounds
+
+{-------------------------------------------------------------------------------
+  Pages (non-partitioned)
+-------------------------------------------------------------------------------}
+
+-- | We model a disk page in a run as a pair of its minimum and maximum key. A
+-- run consists of multiple pages in sorted order, and keys are unique.
+newtype Pages k = Pages { getPages :: [(k, k)]}
+  deriving stock Show
+  deriving newtype NFData
+
+instance (Arbitrary k, Ord k) => Arbitrary (Pages k) where
+  arbitrary = mkPages <$> scale (2*) (arbitrary @[k])
+  shrink (Pages ks) = [Pages ks' | ks' <- shrink ks, pagesInvariant (Pages ks')]
+
+mkPages :: Ord k => [k] -> Pages k
+mkPages ks = Pages $ inPairs $ nubOrd $ sort ks
+
+inPairs :: [k] -> [(k, k)]
+inPairs []             = []
+inPairs [_]            = []
+inPairs (k1 : k2 : ks) = (k1, k2) : inPairs ks
+
+pagesInvariant ::  Ord k => Pages k -> Bool
+pagesInvariant (Pages ks) = nubOrd ks' == ks' && sort ks' == ks'
+  where ks' = flatten ks
+
+flatten :: [(k, k)] -> [k]
+flatten []              = []
+flatten ((k1, k2) : ks) = k1 : k2 : flatten ks
+
+{-------------------------------------------------------------------------------
+  Pages (partitioned)
+-------------------------------------------------------------------------------}
+
+-- | In partitioned pages, all keys inside a page have the same range-finder
+-- bits.
+data PartitionedPages k = PartitionedPages {
+    getRangeFinderPrecision :: RFPrecision
+  , getPartitionedPages     :: [(k, k)]
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass NFData
+
+instance (Arbitrary k, SliceBits k, Integral k) => Arbitrary (PartitionedPages k) where
+  arbitrary = mkPartitionedPages <$> arbitrary <*> arbitrary
+  shrink (PartitionedPages rfprec ks) = [
+        PartitionedPages rfprec ks'
+      | ks' <- shrink ks
+      , partitionedPagesInvariant (PartitionedPages rfprec ks')
+      ] <> [
+        PartitionedPages rfprec' ks
+      | rfprec' <- shrink rfprec
+      , partitionedPagesInvariant (PartitionedPages rfprec' ks)
+      ] <> [
+        PartitionedPages rfprec' ks'
+      | ks' <- shrink ks
+      , rfprec' <- shrink rfprec
+      , partitionedPagesInvariant (PartitionedPages rfprec' ks')
+      ]
+
+mkPartitionedPages ::
+     (SliceBits k, Integral k)
+  => RFPrecision
+  -> Pages k
+  -> PartitionedPages k
+mkPartitionedPages rfprec@(RFPrecision n) (Pages ks) =
+    PartitionedPages rfprec $ filter f ks
+  where
+    f (kmin, kmax) = topBits16 n kmin == topBits16 n kmax
+
+partitionedPagesInvariant :: (SliceBits k, Integral k) => PartitionedPages k -> Bool
+partitionedPagesInvariant (PartitionedPages (RFPrecision rfprec) ks) =
+    pagesInvariant (Pages ks) && properPartitioning
+  where
+    properPartitioning = all p ks
+    p (kmin, kmax) = topBits16 rfprec kmin == topBits16 rfprec kmax

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import qualified Test.Database.LSMTree.Common
+import qualified Test.Database.LSMTree.Generators
 import qualified Test.Database.LSMTree.Internal.Run.BloomFilter
 import qualified Test.Database.LSMTree.Internal.Run.Index.Compact
 import qualified Test.Database.LSMTree.Model.Monoidal
@@ -15,6 +16,7 @@ import           Test.Tasty
 main :: IO ()
 main = defaultMain $ testGroup "lsm-tree"
     [ Test.Database.LSMTree.Common.tests
+    , Test.Database.LSMTree.Generators.tests
     , Test.Database.LSMTree.Internal.Run.Index.Compact.tests
     , Test.Database.LSMTree.Model.Normal.tests
     , Test.Database.LSMTree.Model.Monoidal.tests

--- a/test/Test/Database/LSMTree/Generators.hs
+++ b/test/Test/Database/LSMTree/Generators.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Database.LSMTree.Generators (tests) where
+
+import           Data.Word (Word64)
+import           Database.LSMTree.Generators
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Generators" [
+      testGroup "Range-finder bit-precision" [
+          testProperty "Arbitrary satisfies invariant" $
+            property . rfprecInvariant
+        , testProperty "Shrinking satisfies invariant" $
+            property . all rfprecInvariant . shrink @RFPrecision
+        ]
+    , testGroup "Pages (not partitioned)" [
+          testProperty "Arbitrary satisfies invariant" $
+            property . pagesInvariant @Word64
+        , testProperty "Shrinking satisfies invariant" $
+            property . all pagesInvariant . shrink @(Pages Word64)
+        ]
+    , testGroup "Pages (partitioned)" [
+          testProperty "Arbitrary satisfies invariant" $
+            property . partitionedPagesInvariant @Word64
+        , testProperty "Shrinking satisfies invariant" $
+            property . all partitionedPagesInvariant . shrink @(PartitionedPages Word64)
+        ]
+    ]

--- a/test/Test/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/test/Test/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -3,8 +3,8 @@
 
 module Test.Database.LSMTree.Internal.Run.Index.Compact (tests) where
 
-import           Data.List (nub, sort)
 import           Data.Word (Word64)
+import           Database.LSMTree.Generators
 import           Database.LSMTree.Internal.Run.Index.Compact
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -62,92 +62,3 @@ prop_searchMinMaxKeysAfterConstruction (PartitionedPages (RFPrecision rfprec) ks
          Just idx == x && Just idx == y && Just idx == z
 
 -- TODO: test for arbitrary keys instead of only min and max keys on pages.
-
-{-------------------------------------------------------------------------------
-  Range-finder precision
--------------------------------------------------------------------------------}
-
-newtype RFPrecision = RFPrecision Int
-  deriving Show
-
-instance Arbitrary RFPrecision where
-  arbitrary = RFPrecision <$>
-      (arbitrary `suchThat` (\x -> x >= rfprecLB && x <= rfprecUB))
-  shrink (RFPrecision x) = [RFPrecision x' | x' <- shrink x
-                                           , x' >= rfprecLB && x' <= rfprecUB]
-
-rfprecLB, rfprecUB :: Int
-(rfprecLB, rfprecUB) = rangeFinderPrecisionBounds
-
-{-------------------------------------------------------------------------------
-  Pages (non-partitioned)
--------------------------------------------------------------------------------}
-
--- | We model a disk page in a run as a pair of its minimum and maximum key. A
--- run consists of multiple pages in sorted order, and keys are unique.
-newtype Pages k = Pages { getPages :: [(k, k)]}
-  deriving Show
-
-instance (Arbitrary k, Ord k) => Arbitrary (Pages k) where
-  arbitrary = mkPages <$> scale (2*) (arbitrary @[k])
-  shrink (Pages ks) = [Pages ks' | ks' <- shrink ks, pagesInvariant (Pages ks')]
-
-mkPages :: Ord k => [k] -> Pages k
-mkPages ks0 = Pages $ go $ nub $ sort ks0
-  where
-    go :: [k] -> [(k, k)]
-    go []             = []
-    go [_]            = []
-    go (k1 : k2 : ks) = (k1, k2) : go ks
-
-pagesInvariant ::  Ord k => Pages k -> Bool
-pagesInvariant (Pages ks) = nub ks' == ks' && sort ks' == ks'
-  where ks' = flatten ks
-
-flatten :: [(k, k)] -> [k]
-flatten []              = []
-flatten ((k1, k2) : ks) = k1 : k2 : flatten ks
-
-{-------------------------------------------------------------------------------
-  Pages (partitioned)
--------------------------------------------------------------------------------}
-
--- | In partitioned pages, all keys inside a page have the same range-finder
--- bits.
-data PartitionedPages k = PartitionedPages {
-    getRangeFinderPrecision :: RFPrecision
-  , getPartitionedPages     :: [(k, k)]
-  }
-  deriving Show
-
-instance (Arbitrary k, SliceBits k, Integral k) => Arbitrary (PartitionedPages k) where
-  arbitrary = mkPartitionedPages <$> arbitrary <*> arbitrary
-  shrink (PartitionedPages rfprec ks) = [
-        PartitionedPages rfprec ks'
-      | ks' <- shrink ks
-      , partitionedPagesInvariant (PartitionedPages rfprec ks')
-      ] <> [
-        PartitionedPages rfprec' ks
-      | rfprec' <- shrink rfprec
-      , partitionedPagesInvariant (PartitionedPages rfprec' ks)
-      ] <> [
-        PartitionedPages rfprec' ks'
-      | ks' <- shrink ks
-      , rfprec' <- shrink rfprec
-      , partitionedPagesInvariant (PartitionedPages rfprec' ks')
-      ]
-
-mkPartitionedPages ::
-     (SliceBits k, Integral k)
-  => RFPrecision
-  -> Pages k
-  -> PartitionedPages k
-mkPartitionedPages rfprec (Pages ks) = PartitionedPages rfprec $ filter f ks
-  where f (kmin, kmax) = topBits16 rfprecUB kmin == topBits16 rfprecUB kmax
-
-partitionedPagesInvariant :: (SliceBits k, Integral k) => PartitionedPages k -> Bool
-partitionedPagesInvariant (PartitionedPages (RFPrecision rfprec) ks) =
-    pagesInvariant (Pages ks) && properPartitioning
-  where
-    properPartitioning = all p ks
-    p (kmin, kmax) = topBits16 rfprec kmin == topBits16 rfprec kmax


### PR DESCRIPTION
Some of the code for generators/shrinkers can be shared with the micro-benchmark executable, so I moved it to the utils library