### PR TITLE
Modelled UTxO key for benchmarks and tests

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Run/BloomFilter.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Run/BloomFilter.hs
@@ -9,8 +9,8 @@ import qualified Data.BloomFilter.Easy as Bloom.Easy
 import           Data.Foldable (Foldable (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Word
 import           Database.LSMTree.Extras
+import           Database.LSMTree.Generators
 import           Database.LSMTree.Internal.Run.BloomFilter as Bloom
 import           System.Random
 import           System.Random.Extras
@@ -44,7 +44,7 @@ elemEnv ::
   -> Int    -- ^ Number of entries in the bloom filter
   -> Int    -- ^ Number of positive lookups
   -> Int    -- ^ Number of negative lookups
-  -> IO (Bloom Word64, [Word64])
+  -> IO (Bloom UTxOKey, [UTxOKey])
 elemEnv fpr nbloom nelemsPositive nelemsNegative = do
     stdgen  <- newStdGen
     stdgen' <- newStdGen
@@ -59,7 +59,7 @@ elems :: Bloom a -> [a] -> ()
 elems b xs = foldl' (\acc x -> Bloom.elem x b `seq` acc) () xs
 
 -- | Input environment for benchmarking 'constructBloom'.
-constructionEnv :: Int -> IO (Map Word64 Word64)
+constructionEnv :: Int -> IO (Map UTxOKey UTxOKey)
 constructionEnv n = do
     stdgen  <- newStdGen
     stdgen' <- newStdGen
@@ -69,8 +69,8 @@ constructionEnv n = do
 
 -- | Used for benchmarking the construction of bloom filters from write buffers.
 constructBloom ::
-     (Double -> BloomMaker Word64)
+     (Double -> BloomMaker UTxOKey)
   -> Double
-  -> Map Word64 Word64
-  -> Bloom Word64
+  -> Map UTxOKey UTxOKey
+  -> Bloom UTxOKey
 constructBloom mkBloom fpr m = mkBloom fpr (Map.keys m)

--- a/bench/micro/Bench/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -14,7 +14,6 @@ import qualified Data.Array.Unboxed as A
 import           Data.Foldable (Foldable (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromMaybe)
-import           Data.Word
 import           Database.LSMTree.Generators
 import           Database.LSMTree.Internal.Run.Index.Compact
 import           GHC.Generics
@@ -43,7 +42,7 @@ searchEnv ::
      RFPrecision -- ^ Range-finder bit-precision
   -> Int         -- ^ Number of pages
   -> Int         -- ^ Number of searches
-  -> IO (CompactIndex Word64, [Word64])
+  -> IO (CompactIndex UTxOKey, [UTxOKey])
 searchEnv fpr npages nsearches = do
     ci <- constructCompactIndex <$> constructionEnv fpr npages
     stdgen  <- newStdGen
@@ -63,7 +62,7 @@ searches ci ks = foldl' (\acc k -> f (search k ci) `seq` acc) () ks
 constructionEnv ::
      RFPrecision -- ^ Range-finder bit-precision
   -> Int         -- ^ Number of pages
-  -> IO (Pages Word64)
+  -> IO (Pages UTxOKey)
 constructionEnv rfprec n = do
     stdgen <- newStdGen
     let ks = uniformWithoutReplacement stdgen (2 * n)

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -77,6 +77,7 @@ library lsm-tree-utils
     , lsm-tree
     , QuickCheck
     , random
+    , wide-word
 
 test-suite lsm-tree-test
   import:           warnings


### PR DESCRIPTION
We were using `Word64`s in the benchmarks, but I changed that to `UTxOKey`s (i.e., `Word256`s) to better simulate real workloads