### PR TITLE
Initial versions of file format docs and reference impl for page format

### DIFF
--- a/doc/format-directory.md
+++ b/doc/format-directory.md
@@ -159,8 +159,8 @@ Saving a snapshot involves a few steps:
    - metadata file and metadata checksum file
    - the snapshot directory itself
 
-All five files for each LSM (including the checksum file) are hard-linked into
-the snapshot directory under new number. The number of the file changes
+All five files for each LSM run (including the checksum file) are hard-linked
+into the snapshot directory under new number. The number of the file changes
 because the LSM run numbers within a snapshot are counted from 0 within the
 snapshot, whereas the run numbers in the active directory are shared across all
 open LSM handles. For this reason, the checksum file content uses relative

--- a/doc/format-directory.md
+++ b/doc/format-directory.md
@@ -1,0 +1,18 @@
+% LSM specification: directory and file layouts
+% Duncan Coutts
+
+# Scope
+
+This document is intend to cover the overall LSM directory format, including:
+
+ * persistent snapshots
+ * live handles
+ * sufficient checksum/consistency info to detect directory corruption
+   (not just individual file content corruption)
+ * high-level configuration options persisted to files (if necessary)
+
+This document is part of a group of documents that cover the formats:
+ * `format-directory.md`: covering the overall LSM directory format
+ * `format-run.md`: covering the LSM file-run format
+ * `format-page.md`: covering the LSM file-run _page_ format
+

--- a/doc/format-directory.md
+++ b/doc/format-directory.md
@@ -16,3 +16,163 @@ This document is part of a group of documents that cover the formats:
  * `format-run.md`: covering the LSM file-run format
  * `format-page.md`: covering the LSM file-run _page_ format
 
+
+# Top level layout
+
+The filesystem representation for an LSM session lives under a single directory
+structure. We will describe all files relative to this `${session}` root.
+
+The top level directory contains
+
+ * `${session}/lock` file
+ * `${session}/active/` directory
+ * `${session}/snapshots/` directory
+
+The top level lock file is used with an OS file lock API to (cooperatively)
+ensure exclusive use of a session. It is otherwise empty.
+
+# Active directory layout
+
+The ephemeral directory contains all of the files for all the LSM runs that are
+in use by any open LSM handle in the session.
+
+ * `${session}/active/${n}.keyops`
+ * `${session}/active/${n}.filter`
+ * `${session}/active/${n}.index`
+ * `${session}/active/${n}.checksums`
+
+The LSM runs are numbered using a session-wide counter that is initialised from
+0 each time a session is opened.
+
+Note that there are no metadata files in the active directory (as there are for
+snapshots). This is because the metadata is held in memory for open LSM handles.
+
+# Snapshots directory layout
+
+Each snapshot has a name in a session-wide namespace, and gets a corresponding
+subdirectory:
+
+ * `${session}/snapshots/${name}/` directory
+
+Thus the limitations on portable file/directory names applies to snapshot names.
+
+Each snapshot contains a metadata file for the snapshot overall and a checksum:
+
+ * `${session}/snapshots/${name}/snapshot`
+ * `${session}/snapshots/${name}/snapshot.checksum`
+
+plus the five files for each LSM run in the snapshot:
+
+ * `${session}/snapshots/${name}/${n}.keyops`
+ * `${session}/snapshots/${name}/${n}.blobs`
+ * `${session}/snapshots/${name}/${n}.filter`
+ * `${session}/snapshots/${name}/${n}.index`
+ * `${session}/snapshots/${name}/${n}.checksum`
+
+In this case the LSM run files are numbered from 0 within each snapshot.
+
+## Snapshot metadata
+
+The snapshot metadata file contains the following information:
+ * A format version/tag identifier
+ * The stored parameters for the LSM table (specified when the table was
+   originally created), including
+   - LSM tuning parameters
+   - Page size for all the key/operations files
+   - Index type and parameters
+ * Key/value type information for dynamic-type sanity checking
+ * The shape of the LSM tree overall (runs within levels etc), referencing
+   the numbered LSM runs.
+
+There is a separate `snapshot.checksum` file containing the checksum of the
+metadata file.
+
+In particular, the snapshot metadata file tells us exactly which other LSM run
+files to expect. This is important for detecting filesystem corruption.
+
+# LSM run file layout
+
+Each completed LSM run has five files:
+
+ 1. `${n}.keyops`: the sorted run of key/operation pairs
+ 2. `${n}.blobs`:  the blob values associated with the key/operations
+ 3. `${n}.filter`: a Bloom filter of all the keys in the run
+ 4. `${n}.index`:  an index from keys to disk page numbers
+ 5. `${n}.checksum`: a file listing the crc32c checksums of the other files
+
+The format of the main four files is covered in `format-run.md`.
+
+Each in-progress LSM run has only the main files, but no checksum file, and the
+main files will be in some intermediate state of construction.
+
+# Checksum files
+
+Each `.checksum` file lists the CRC-32C (Castagnoli) of other files.
+
+The file uses the BSD-style checksum format (e.g. as produced by tools like
+`md5sum --tag`), with the algorithm name "CRC32C". This format is text,
+one line per file, using hexedecimal for the 32bit output.
+
+Checksum files are used for each LSM run, and for the snapshot metadata.
+```
+CRC32C (keyops) = fd040004
+CRC32C (blobs) = 5a3b820c
+CRC32C (filter) = 6653e178
+CRC32C (index) = f4ec6724
+```
+```
+CRC32C (snapshot) = 87972d7f
+```
+Note that the checksum file for LSM runs _does not_ include the full name of
+each file, such as `0.keyops`. It excludes the number from the file name. The
+number is instead implicit from the name of the checksum file, e.g.
+`0.checksum` contains checksums for `0.*` files.
+
+The reason for this kind of "relative" naming, is because when the LSM runs
+are moved between active and snapshot, the number of the LSM run will change,
+and by using relative names, we avoid having to rewrite the checksum files,
+and can instead just hard link them.
+
+# Verifying snapshots
+
+The checksum of the snapshot metadata must be verified.
+
+The snapshot metadata file then determines the number of LSM runs within the
+snapshot. Each numbered run within the snapshot must have a checksum file,
+which must list the other files.
+
+The checksum of each LSM run file must be verified.
+
+If verfification passes, this ensures all the files are present and have their
+expected content. The use of CRCs protects against accidental corruption, not
+deliberate corruption.
+
+# Saving and restoring snapshots using hard links
+
+Saving a snapshot involves a few steps:
+
+ 1. creating a _new_ directory for the snapshot
+ 2. writing out the snapshot metadata file and checksum
+ 3. hard linking all the LSM run files into the snapshot directory
+ 4. for durability, `fsync`:
+   - all the LSM run files, including checksum files
+   - metadata file and metadata checksum file
+   - the snapshot directory itself
+
+All five files for each LSM (including the checksum file) are hard-linked into
+the snapshot directory under new number. The number of the file changes
+because the LSM run numbers within a snapshot are counted from 0 within the
+snapshot, whereas the run numbers in the active directory are shared across all
+open LSM handles. For this reason, the checksum file content uses relative
+file names, without mentioning the number.
+
+Restoring a snapshot involves:
+
+ 1. verifying the snapshot (optional, depending on paranoia)
+ 2. loading the snapshot metadata
+ 3. hard linking all the LSM run files from the snapshot into the active
+    directory
+
+All five files for each LSM (including the checksum file) are hard-linked into
+the active directory under a new number. The LSM runs in the active directory
+are numbered sequentially across all open LSM handles.

--- a/doc/format-page.md
+++ b/doc/format-page.md
@@ -1,0 +1,260 @@
+% LSM specification: LSM file-run page format
+% Duncan Coutts
+
+# Scope
+
+This document is intend to cover the format of the pages within the
+key/operation file of each LSM run, including:
+
+* page header for metadata
+* "normal" pages of k/op pairs
+* encoding of insert/delete/update operations
+* encoding of monoidal update operations
+* encoding of references to blobs
+
+This document is part of a group of documents that cover the formats:
+ * `format-directory.md`: covering the overall LSM directory format
+ * `format-run.md`: covering the LSM file-run format
+ * `format-page.md`: covering the LSM file-run _page_ format
+
+# Page format considerations
+
+The key/operations file encodes the main part of the LSM key value mapping.
+Logically, a page consists of a value of type
+```
+type Page = [(Key, Operation, Maybe BlobRef)]
+```
+where the operation can be insert (with a value), delete (with no value) or
+mupsert (with a value). The entries are sorted by key.
+
+The file is structured in a page-oriented way to support efficient I/O using
+random page-sized reads. By page-oriented we mean that the information is
+structured to be read in units of whole pages, one or more.
+
+The literature suggests that 4k pages are the best default choice for databases
+for current hardware for random lookups, and as such the page size used in the
+file is 4k. Typically we expect a single 4k page to contain several
+key/operation pairs, but there is support for "overflow" pages, where a single
+value is so large that it needs multiple pages. Keys however are limited in
+size, and cannot exceed a single 4k page.
+
+The page format should be designed to support the LSM lookup operation
+efficiently. Lookup works by loading the 4k page on which the key (probably)
+exists, and then searching for the key/operation pair within the page. Thus an
+efficient design should minimise any decoding overhead, and enable efficient
+search. The approach we take is to design the page format to require no copying
+or allocation with minimal computation for decoding, and to keep the keys
+together in a sorted dense list.
+
+We assume that both keys and values are byte strings of variable size.
+
+For the special case of a single value that spans multiple pages, the number of
+pages will be discovered during the lookup operation from the index and so all
+the required pages will be read in at once. The pages ready in do not need to
+be contiguous in memory.
+
+## Representation sizes
+
+The concrete representation is chosen to balance a couple factors: speed of
+access (for lookup operations) and size. We choose to make all values be
+naturally aligned relative to the page, e.g. 2-byte values at 2-byte offsets.
+This means that if a page from disk is loaded into a 4k aligned page in memory
+(as is required anyway for `O_DIRECT`) then all memory access will be naturally
+aligned, and thus it will be unnecessary to use unaligned memory operations.
+
+For offsets within the page, we can use 16 bits. Since 4k is 2^12, this leaves
+4 bits spare. This could be used to allow for larger pages, up to 64k.
+
+# Page format representation
+
+A page consists of:
+
+1. A directory of the other components
+   - 8-byte size
+2. An array of 1-bit blob reference indicators
+   - a packed array (i.e. a bitmap), 1 element per key
+   - padded to 8-byte size
+3. An array of 2-bit operation types
+   - a packed array, 1 element per key
+   - padded to 8-byte size
+4. A pair of arrays of blob references
+   - each blob reference is a 64bit offset and 32bit length
+   - an array of 64bit offset values
+   - an array of 32bit length values
+5. An array of key offsets
+   - 16bit offsets (to start of each key), 1 element per key
+6. An array of value offsets
+   - 16bit offsets (to start of each value), 1 element per key (not value)
+   - +1 last offset for offset 1 past last value
+   - special case when the page contains just 1 key/op pair: the last offset
+     is 32bit, not 16bit. So overall in this case there are two offsets, a
+     16bit start and 32bit end offset, each naturally aligned
+7. The concatenation of all keys
+   - the byte span for individual keys is derived from the offsets array
+8. The concatenation of all values
+   - the byte span for individual value is derived from the offsets array
+   - for the 1-element case, this value may span multiple overflow pages
+
+The somewhat odd order of the entries is due to representation issues:
+
+* we want to allow for natural memory address alignment of all data
+* we also want compact representation without too much space wasted to padding
+* we want to take advantage of cache line loads
+* we want to keep offset computation fast but not have to store lots of offsets
+
+## Page directory
+
+The page directory stores enough information to compute the offsets of all
+components of the page structure. Specifically it stores
+
+1. N: the number of key/op pairs in this page
+2. B: the number of blobrefs in this page
+3. KO: offset to the array of key offsets (component 5)
+4. unused/spare
+
+Each of these is represented as a 16bit value, for a total of 64bits.
+
+The size of each component (in bytes) is as follows:
+1. 8
+2. (N + 63) `shiftR` 3 .&. complement 0x7   (N bits rounded up to 64)
+3. (2*N + 63) `shiftR` 3 .&. complement 0x7 (2N bits rounded up to 64)
+4. 12*B                                     (where B is number of blobrefs)
+5. 2*N
+6. 2*(N+1) when N>1
+   6       when N=1
+7. sum (map length keys)
+8. sum (map length values)
+
+The page offset of each component can be computed as follows:
+
+1. 0
+2. 8
+3. 8 + ((N + 63) `shiftR` 3 .&. complement 0x7)
+4. (stored offset KO) - 12*B
+5. (stored offset KO)
+6. (stored offset KO) + 2*N
+7. entry 0 in array of key offsets
+8. entry 0 in array of value offsets
+
+## Page size tracking
+
+When packing key/operation/blobref tuples into pages, we need to be able to
+accurately predict the size of the serialised representation to make sure that
+we do not overflow a page.
+
+The size can be tracked incrementally as follows:
+
+Start with N = 0, B = 0, size = 10 bytes.
+
+When adding an element (k, op(v), b):
+
+* Increment N by 1
+* Increment B by 1 if a blobref is present
+* Increment size by the sum of:
+   + 8 if N mod 64 == 0
+   + 8 if N mod 32 == 0
+   + 12 if blobref is present
+   + 2
+   + 4 if N==0, 0 if N==1 and 2 otherwise
+   + len k
+   + len v  (or 0 if op is delete)
+
+## Page size overheads
+
+The biggest key that can fit into a page is determined by the overheads for the
+page representation.
+
+We can calculate this. If conservatively assume a blobref is present.
+
+The page size formula above gives us the sum of:
+ + 10
+ + 8
+ + 8
+ + 12
+ + 2
+ + 4
+
+Which is 44 bytes, not including the key itself. Thus the maximum key size can
+be the page size minus 44 bytes.
+
+## Blob reference indicators
+
+This is a bitmap with a bit for each key/operation pair, indicating whether
+there is an associated blob reference or not.
+
+The bitmap is aligned and padded to 64 bits so that the bitmap operation can
+use 64 bit word operations. The bitmap is arranged in words of 64 bits, in
+little endian format.
+
+The bitmap is indexed by taking the query index, shifting right 6 bits to
+obtain which 64bit word to inspect, and then within the 64bit word, selecting
+bit i where i is the lower 6 bits of the query index. The selected bit
+indicates whether a blob reference is present for this key.
+
+## Blob reference arrays
+
+Each blob reference is a 64bit byte offset and a 32bit byte length. This
+identifies a span of bytes within the LSM run blob file associated with this
+key/operations file.
+
+The pair of blob reference arrays gives the actual blob reference values. They
+only contain entries for keys that have blob references. It is organised as a
+pair of arrays, rather than an array of pairs. This is because the two
+components of a blob reference are 64bit and 32bit and using a pair of arrays
+representation gives natural alignment without any padding.
+
+If the blob reference bitmap indicates that there is a blob reference for key i,
+then the index in the blob reference array can be found by counting the number
+of 1 bits for all bitmap indexes stricly less than i. This can be done
+relatively efficiently using the popcount CPU instruction. For example, pages
+with up to 64 keys, the bitmap fits into a single 64bit word and thus a single
+popcount instruction, (and some bit shifting and masking) is needed to find the
+index of the blob reference.
+
+## Key offsets
+
+This is an array of 16bit values. There are N entries. Entry i (indexed from 0)
+gives the offset within the page of the start of the key byte string. Entry i+1
+therefore gives the offset one past each key. This provides a span for the key.
+For the final key, key N-1, we can still use N-1 and N, even though there are
+only N entries, because we arrange that the value offset array comes
+immediately after the key offset array, and the first entry of the value offset
+array will be one past the final key (because the value byte strings themselves
+come immediately after the key byte strings).
+
+## Value offsets
+
+Except for the special case of N=1, this is an array of 16bit values, with N+1
+entries. In the usual case, we can find the value byte string span from index
+i and i+1.
+
+For the special case of N=1, the representation is two offsets, but the second
+offset is 32bit rather than 16bit. This is to allow for very large values that
+take more than one page (or indeed more than 64k).
+
+Note that the 32bit value will still be naturally aligned, because the key
+offset array is aligned to 32bit, and for N=1, the value offset array will be
+at a 16bit but not 32bit alignment, and therefore after the 16bit entry in the
+value offset array, we get back to 32bit alignment.
+
+This combination of using only N rather than N+1 key offsets, and having the
+N=1 special case use 16 + 32bit is a bit of a cunning hack, but it means we
+need no extra padding and get natural alignment. This makes page size
+calculations simpler and saves space. There is only a modest complexity cost
+to the N=1 special case.
+
+## Key and value byte strings
+
+This is the concatenation of all the key byte strings, follow by all the value
+byte strings. The spans are given by the key and value offset arrays.
+
+Note that the concatenation of keys must fit within the first page, but for the
+special case of N=1, the value may span multiple pages.
+
+This restriction allows the key search to be simple by not having to deal with
+non-contiguous memory pages. For the special case of N=1 where multiple pages
+need to be read in from disk, the pages do not need to be contiguous in memory.
+This allows the I/O buffer strategy to be simple by only having to deal with
+single pages. Then the only code that has to deal with page boundaries is
+copying the value byte string.
+

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -1,0 +1,22 @@
+% LSM specification: LSM file-run format
+% Duncan Coutts
+
+# Scope
+
+This document is intend to cover the format of the files used to represent an
+individual LSM run, including:
+
+* any header for metadata
+* bloom filters
+* indexes
+* key/operation pages (but the page format is covered in `format-page.md`)
+* blob files for large additional values (blobs can vary in size, but we can
+  design performance for a range, e.g. 1-16kb, and can impose an upper bound)
+* separate files for: k/ops, blobs, and index & filter
+* checksums for all files
+
+This document is part of a group of documents that cover the formats:
+ * `format-directory.md`: covering the overall LSM directory format
+ * `format-run.md`: covering the LSM file-run format
+ * `format-page.md`: covering the LSM file-run _page_ format
+

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -22,14 +22,14 @@ This document is part of a group of documents that cover the formats:
 
 # LSM runs
 
-Each LSM run consists of three components:
+Each LSM run consists of four components:
 
 1. the sorted run of key/operation pairs
 2. the blobs associated with the key/operation pairs, if any
 3. a Bloom filter of all the keys in the run
 4. an index from keys to disk page numbers
 
-Each one is represented on-disk in a separate file. Thus there are three files
+Each one is represented on-disk in a separate file. Thus there are four files
 per run.
 
 ## Represented in memory or on-disk
@@ -38,7 +38,7 @@ The bloom filter and index are loaded into memory when the LSM run is in use.
 The key/operations and blob files remain primarily on disk and pages are loaded
 as needed for lookup and merge operations.
 
-## Inhereited metadata
+## Inherited metadata
 
 Metadata is kept at the LSM handle level, not per-run. This is because we
 expect all metadata to be the same for all runs in an LSM tree.
@@ -61,7 +61,7 @@ This file contains all the key/operation/blobref entries for the LSM run,
 sorted by key and arranged into pages. The individual page format is detailed
 in `format-page.md`.
 
-The overall file format consists exclusivly of these pages, with no additional
+The overall file format consists exclusively of these pages, with no additional
 metadata or file headers. The page size will typically be 4k but can be any
 power of 2 up to 64k.
 
@@ -103,7 +103,7 @@ numbers.
 * 32k pages, 2^15-44, rounded: 32,000
 * 64k pages, 2^16-44, rounded: 64,000
 
-The maximum value size is 2^32-1 less the page overhead, and conservatively
+The maximum value size is 2^32-1 minus the page overhead, and conservatively
 assuming a maximum sized key with maximum page size. This is approximately
 2^32 - 2^16 - 1 = 4294901759, though this limit could also be rounded down in
 a public API.
@@ -111,11 +111,11 @@ a public API.
 ## Blobs file
 
 Each key/operation in the key/operations file optionally contains a blob
-references. A blob reference is of course a reference to a blob value, which
+reference. A blob reference is of course a reference to a blob value, which
 is simply a sequence of bytes. These blob values are stored in the blobs file.
 
-The representation of a blob reference is a 64bit byte file offset and a 32bit
-byte length. This identifies a span of bytes within this blob file.
+The representation of a blob reference is a 64bit file offset (in bytes) and a
+32bit length (in bytes). This identifies a span of bytes within this blob file.
 
 The file format is simple: the concatenation of all the blob values, in the
 same order as the key/operations that refer to the blobs (which is sorted by
@@ -152,7 +152,7 @@ indicates the endianness of the 32bit words.
 The index maps keys to the number of the disk page(s) in the key/operation file
 that _could_ contain this key.
 
-That is, the index says where the key could possiblly be, and thus what pages
+That is, the index says where the key could possibly be, and thus what pages
 to load from disk to search for the key. The index does not say whether a key
 exists or not (the bloom filter does this, albeit probabilistically, with false
 positives).
@@ -164,13 +164,13 @@ for the first page to indicate that it is a multi-page value, and then require
 a second round of disk I/O to read in the remaining pages.)
 
 The design is intended to be somewhat extensible by allowing for different
-choices of index representation, to suite different kinds of key and key
+choices of index representation, to suit different kinds of key and key
 properties. In particular initially we will support a compact index type.
-For more general purpose applications one can forsee the need for a more
+For more general purpose applications one can foresee the need for a more
 ordinary index type.
 
-The type of index in use is metadata that must be known for the whole LSM tree.
-It does not vary per run.
+The type of index in use is metadata that must be known for the whole LSM table
+handle. It does not vary per run.
 
 ### Compact index
 
@@ -186,7 +186,7 @@ is a factor of 8 saving for 32 byte keys.
 
 The representation consists of
 1. the number of range finder bits (0..16)
-2. a range finder array, of 2^n entries of 32bit each (n = range finder bits)
+2. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
 3. a primary array of 32bit words, one entry per page in the index
 4. a clash indicator bit vector, one bit per page in the index
 5. a clash map, mapping each page with a clash indicator to the full minimum

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -20,3 +20,197 @@ This document is part of a group of documents that cover the formats:
  * `format-run.md`: covering the LSM file-run format
  * `format-page.md`: covering the LSM file-run _page_ format
 
+# LSM runs
+
+Each LSM run consists of three components:
+
+1. the sorted run of key/operation pairs
+2. the blobs associated with the key/operation pairs, if any
+3. a Bloom filter of all the keys in the run
+4. an index from keys to disk page numbers
+
+Each one is represented on-disk in a separate file. Thus there are three files
+per run.
+
+## Represented in memory or on-disk
+
+The bloom filter and index are loaded into memory when the LSM run is in use.
+The key/operations and blob files remain primarily on disk and pages are loaded
+as needed for lookup and merge operations.
+
+## Inhereited metadata
+
+Metadata is kept at the LSM handle level, not per-run. This is because we
+expect all metadata to be the same for all runs in an LSM tree.
+
+There are some bits of metadata from the LSM handle that we rely on for
+interpreting or creating the LSM run files:
+
+* Page size: the key/operations file is structured as pages for efficient I/O.
+  These pages will typically be 4k, but the format could support 8k, 16k, 32k
+  or 64k pages.
+* Index type: in principle we could support multiple index representations,
+  to suit different kinds and properties of key (e.g. fixed size, uniformly
+  distributed). Initially we will support a compact index type suited to
+  uniformly distributed keys of variable size but with at least 48bits.
+* The compact index "range finder" bits (if a compact index is used).
+
+## Key/operations file
+
+This file contains all the key/operation/blobref entries for the LSM run,
+sorted by key and arranged into pages. The individual page format is detailed
+in `format-page.md`.
+
+The overall file format consists exclusivly of these pages, with no additional
+metadata or file headers. The page size will typically be 4k but can be any
+power of 2 up to 64k.
+
+The run is sorted by key, based on the usual key byte string representation.
+The number of each disk page within the file is significant, as this page
+number is what is stored within the LSM run index, to enable easily finding the
+right disk page(s) to read for a lookup operation. Pages are numbered from 0.
+
+The key/operations are organised into pages in the following way:
+
+* All the keys in a page must have the same "range finder" bits, if a compact
+  index is in use. For code uniformity, if a compact index is not used then
+  this is equivalent to using 0 range finder bits. This restriction is needed
+  to support the compact index representation.
+  
+  When packing key/operations into pages linearly, the initial key bits can be
+  tracked and when they change from one key to the next, then a page boundary
+  must be used, at the expense of wasting any remaining space in the page. The
+  range finder bits are chosen to not cause excessive waste.
+
+* Otherwise, key/operation/blobrefs are packed into pages so that as many fit
+  as possible, given the size limit of the page format. The details of the size
+  of pages is given in `format-page.md`.
+
+* For the special case of N=1, the value can be large and span multiple pages.
+
+* In all other cases, N>1, all entries must fit within a single page.
+
+### Maximum key and value sizes
+
+The maximum key size is limited by what can fit within a page, thus the
+maximum key size depends on the page size. The page size overhead (derived in
+`format-page.md`) is 44 bytes. We can however round to more "sensible" looking
+numbers.
+
+* 4k pages:  2^12-44, rounded: 4,000
+* 8k pages,  2^13-44, rounded: 8,000
+* 16k pages, 2^14-44, rounded: 16,000
+* 32k pages, 2^15-44, rounded: 32,000
+* 64k pages, 2^16-44, rounded: 64,000
+
+The maximum value size is 2^32-1 less the page overhead, and conservatively
+assuming a maximum sized key with maximum page size. This is approximately
+2^32 - 2^16 - 1 = 4294901759, though this limit could also be rounded down in
+a public API.
+
+## Blobs file
+
+Each key/operation in the key/operations file optionally contains a blob
+references. A blob reference is of course a reference to a blob value, which
+is simply a sequence of bytes. These blob values are stored in the blobs file.
+
+The representation of a blob reference is a 64bit byte file offset and a 32bit
+byte length. This identifies a span of bytes within this blob file.
+
+The file format is simple: the concatenation of all the blob values, in the
+same order as the key/operations that refer to the blobs (which is sorted by
+key). There is no additional padding or alignment.
+
+This simple format supports writing out the LSM run incrementally, as entries
+are added sequentially in key order. Blobs are retrieved simply by reading the
+blob span into memory.
+
+To keep things simple and uniform, there is no special case for the empty
+sequence of blobs: it is represented by an empty blobs file.
+
+## Bloom filter file
+
+The format of this file consists of a header, followed by the bloom filter bit
+vector.
+
+The first 4 bytes (32bit) are a format identifier / format version. This
+determines the format of the rest of the header and file.
+
+The remainder of the header for format 0 consists of:
+ 1. The hash function count (32bit)
+ 2. The bit size of the filter (32bit)
+ 3. A boolean to indicate endianness, 0 little, 1 big (32bit)
+
+The family of hash functions to use is implied by the format version.
+
+The filter bit vector itself is organised as a whole number of 32bit words.
+It follows immediately after the header. The endianness from the header
+indicates the endianness of the 32bit words.
+
+## Index file
+
+The index maps keys to the number of the disk page(s) in the key/operation file
+that _could_ contain this key.
+
+That is, the index says where the key could possiblly be, and thus what pages
+to load from disk to search for the key. The index does not say whether a key
+exists or not (the bloom filter does this, albeit probabilistically, with false
+positives).
+
+For the case of large values that require multiple pages, the index must report
+the span of disk pages that the key/operation may be on. This allows the whole
+range of pages to be read from disk in one go. (An alternative design would be
+for the first page to indicate that it is a multi-page value, and then require
+a second round of disk I/O to read in the remaining pages.)
+
+The design is intended to be somewhat extensible by allowing for different
+choices of index representation, to suite different kinds of key and key
+properties. In particular initially we will support a compact index type.
+For more general purpose applications one can forsee the need for a more
+ordinary index type.
+
+The type of index in use is metadata that must be known for the whole LSM tree.
+It does not vary per run.
+
+### Compact index
+
+The compact index type is designed to work with keys that are large
+cryptographic hashes, e.g. 32 bytes. In particular it requires:
+
+* keys must be uniformly distributed
+* keys must be at least 6 bytes (48bits), but can otherwise be variable length
+
+For this important special case, we can do significantly better than storing a
+whole key per page: we can typically store just 4 bytes (32bits) per page. This
+is a factor of 8 saving for 32 byte keys.
+
+The representation consists of
+1. the number of range finder bits (0..16)
+2. a range finder array, of 2^n entries of 32bit each (n = range finder bits)
+3. a primary array of 32bit words, one entry per page in the index
+4. a clash indicator bit vector, one bit per page in the index
+5. a clash map, mapping each page with a clash indicator to the full minimum
+   key for the page
+
+The file format consists of each part, sequentially within the file. This
+format can in-part be written out incrementally as the index is constructed.
+The primary array is the largest component, and this is the part that can be
+written out to disk incrementally. Its size is bounded but not known precisely
+prior to the completion of the index. The range finder array cannot be written
+until index completion, but its size is known in advance and so space in the
+file can be reserved. The clash indicator bit vector has the same number of
+elements as the primary array, but is of course 32 times smaller, so it is
+reasonable to keep this in memory while the index is constructed and flush it
+upon completion. Similarly, the clash map is small and it can be written upon
+index completion.
+
+### Ordinary index
+
+The ordinary index type is intended to cover a general use case and not have
+any special constraints on the key. The ordinary index supports variable sized
+byte string keys, and makes worst case assumptions about key distribution.
+
+It is represented as a simple fence pointer index, storing the first key in
+each page.
+
+TODO: flesh out the representation if/when this gets implemented.

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -235,11 +235,14 @@ test-suite lsm-prototypes
   hs-source-dirs:   prototypes test
   main-is:          Test.hs
   other-modules:
+    FormatPage
     ScheduledMerges
     ScheduledMergesTestQLS
 
   build-depends:
     , base
+    , binary
+    , bytestring
     , constraints
     , containers
     , contra-tracer

--- a/prototypes/FormatPage.hs
+++ b/prototypes/FormatPage.hs
@@ -1,0 +1,502 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE RecordWildCards  #-}
+
+-- | This accompanies the format-page.md documentation as a sanity check
+-- and a precise reference. It is intended to demonstrate that the page
+-- format works.
+--
+module FormatPage (tests) where
+
+import           Data.Bits
+import           Data.Function (on)
+import           Data.List (foldl', sortBy, unfoldr)
+import           Data.Maybe (fromJust, isJust)
+import           Data.Word
+
+import qualified Data.Binary.Get as Bin
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BSL
+
+import           Control.Exception (assert)
+import           Control.Monad
+
+import           Test.QuickCheck hiding ((.&.))
+import           Test.Tasty
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+-- | Logically, a page is a sequence of key,operation pairs (with optional
+-- blobrefs), sorted by key.
+newtype PageLogical = PageLogical [(Key, Operation, Maybe BlobRef)]
+  deriving (Eq, Show)
+
+newtype Key   = Key   ByteString deriving (Eq, Ord, Show)
+newtype Value = Value ByteString deriving (Eq, Show)
+
+data Operation = Insert  Value
+               | Mupsert Value
+               | Delete
+  deriving (Eq, Show)
+
+data BlobRef = BlobRef Word64 Word32
+  deriving (Eq, Show)
+
+-- | A serialised page is 4k bytes (or 8,16,32 or 64k for big pages).
+--
+type PageSerialised = ByteString
+
+data PageIntermediate =
+     PageIntermediate {
+       pageNumKeys       :: !Word16,
+       pageNumBlobs      :: !Word16,
+       pageSizesOffsets  :: !PageSizesOffsets,
+       pageBlobRefBitmap :: [Bool],
+       pageOperations    :: [OperationEnum],
+       pageBlobRefs      :: [BlobRef],
+       pageKeyOffsets    :: [Word16],
+       pageValueOffsets  :: Either [Word16] (Word16, Word32),
+       pageKeys          :: !ByteString,
+       pageValues        :: !ByteString
+     }
+  deriving (Eq, Show)
+
+data OperationEnum = OpInsert | OpMupsert | OpDelete
+  deriving (Eq, Show)
+
+data PageSizesOffsets =
+     PageSizesOffsets {
+       sizeDirectory     :: !Word16,
+       sizeBlobRefBitmap :: !Word16,
+       sizeOperations    :: !Word16,
+       sizeBlobRefs      :: !Word16,
+       sizeKeyOffsets    :: !Word16,
+       sizeValueOffsets  :: !Word16,
+       sizeKeys          :: !Word16,
+       sizeValues        :: !Word32,
+
+       offBlobRefBitmap  :: !Word16,
+       offOperations     :: !Word16,
+       offBlobRefs       :: !Word16,
+       offKeyOffsets     :: !Word16,
+       offValueOffsets   :: !Word16,
+       offKeys           :: !Word16,
+       offValues         :: !Word16,
+
+       sizePageTotal     :: !Word32
+     }
+  deriving (Eq, Show)
+
+calcPageSizeOffsets :: Word16 -> Word16 -> Word16 -> Word32 -> PageSizesOffsets
+calcPageSizeOffsets n b sizeKeys sizeValues =
+    PageSizesOffsets {..}
+  where
+    sizeDirectory     = 8
+    sizeBlobRefBitmap = (n + 63) `shiftR` 3 .&. complement 0x7
+    sizeOperations    = (2 * n + 63) `shiftR` 3 .&. complement 0x7
+    sizeBlobRefs      = (4 + 8) * b
+    sizeKeyOffsets    = 2 * n
+    sizeValueOffsets  | n == 1    = 6
+                      | otherwise = 2 * (n+1)
+
+    offBlobRefBitmap  =                    sizeDirectory
+    offOperations     = offBlobRefBitmap + sizeBlobRefBitmap
+    offBlobRefs       = offOperations    + sizeOperations
+    offKeyOffsets     = offBlobRefs      + sizeBlobRefs
+    offValueOffsets   = offKeyOffsets    + sizeKeyOffsets
+    offKeys           = offValueOffsets  + sizeValueOffsets
+    offValues         = offKeys          + sizeKeys
+    sizePageTotal     = fromIntegral offValues + sizeValues
+
+data PageSize = PageSize {
+                  pageSizeElems :: !Int,
+                  pageSizeBlobs :: !Int,
+                  pageSizeBytes :: !Int
+                }
+  deriving (Eq, Show)
+
+pageSizeEmpty :: PageSize
+pageSizeEmpty = PageSize 0 0 10
+
+pageSizeAddElem :: (Key, Operation, Maybe BlobRef)
+                -> PageSize -> Maybe PageSize
+pageSizeAddElem (Key key, op, mblobref) (PageSize n b sz)
+  | sz' <= 4096 || n' == 1 = Just (PageSize n' b' sz')
+  | otherwise              = Nothing
+  where
+    n' = n+1
+    b' | isJust mblobref = b+1
+       | otherwise       = b
+    sz' = sz
+        + (if n `mod` 64 == 0 then 8 else 0)    -- blobrefs bitmap
+        + (if n `mod` 32 == 0 then 8 else 0)    -- operations bitmap
+        + (if isJust mblobref then 12 else 0)   -- blobref entry
+        + 2                                     -- key offsets
+        + (case n of { 0 -> 4; 1 -> 0; _ -> 2}) -- value offsets
+        + BS.length key
+        + (case op of
+             Insert  (Value v) -> BS.length v
+             Mupsert (Value v) -> BS.length v
+             Delete            -> 0)
+
+calcPageSize :: PageLogical -> Maybe PageSize
+calcPageSize (PageLogical kops) =
+    go pageSizeEmpty kops
+  where
+    go !pgsz [] = Just pgsz
+    go !pgsz ((key, op, mblobref):kops') =
+      case pageSizeAddElem (key, op, mblobref) pgsz of
+        Nothing    -> Nothing
+        Just pgsz' -> go pgsz' kops'
+
+encodePage :: PageLogical -> PageIntermediate
+encodePage (PageLogical kops) =
+    PageIntermediate {..}
+  where
+    pageNumKeys, pageNumBlobs :: Word16
+    pageNumKeys       = fromIntegral (length kops)
+    pageNumBlobs      = fromIntegral (length [ b | (_,_, Just b) <- kops ])
+
+    pageSizesOffsets@PageSizesOffsets {offKeys, offValues}
+                      = calcPageSizeOffsets
+                          pageNumKeys pageNumBlobs
+                          (fromIntegral (BS.length pageKeys))
+                          (fromIntegral (BS.length pageValues))
+
+    pageBlobRefBitmap = [ isJust mblobref | (_,_, mblobref) <- kops ]
+    pageOperations    = [ toOperationEnum op | (_,op,_) <- kops ]
+    pageBlobRefs      = [ blobref | (_,_, Just blobref) <- kops ]
+
+    keys              = [ k | (k,_,_)  <- kops ]
+    values            = [ v | (_,op,_)  <- kops
+                        , let v = case op of
+                                    Insert  v' -> v'
+                                    Mupsert v' -> v'
+                                    Delete     -> Value (BS.empty)
+                        ]
+
+    pageKeyOffsets    = init $ scanl (\o k -> o + keyLen16 k)
+                                     offKeys keys
+    pageValueOffsets  = case values of
+                          [v] -> Right (offValues,
+                                        fromIntegral offValues
+                                        + valLen32 v)
+                          _   -> Left  (scanl (\o v -> o + valLen16 v)
+                                              offValues values)
+    pageKeys          = BS.concat [ k | Key   k <- keys ]
+    pageValues        = BS.concat [ v | Value v <- values ]
+
+    toOperationEnum Insert{}  = OpInsert
+    toOperationEnum Mupsert{} = OpMupsert
+    toOperationEnum Delete{}  = OpDelete
+
+    keyLen16 :: Key -> Word16
+    valLen16 :: Value -> Word16
+    valLen32 :: Value -> Word32
+    keyLen16 (Key   k) = fromIntegral $ BS.length k
+    valLen16 (Value v) = fromIntegral $ BS.length v
+    valLen32 (Value v) = fromIntegral $ BS.length v
+
+serialisePage :: PageIntermediate -> PageSerialised
+serialisePage PageIntermediate{pageSizesOffsets = PageSizesOffsets{..}, ..} =
+    BSL.toStrict . BB.toLazyByteString $
+
+    -- the top level directory
+    BB.word16LE pageNumKeys
+ <> BB.word16LE pageNumBlobs
+ <> BB.word16LE offKeyOffsets
+ <> BB.word16LE 0 --spare
+ <> mconcat [ BB.word64LE w | w <- toBitmap pageBlobRefBitmap ]
+ <> mconcat [ BB.word64LE w | w <- toBitmap . concatMap opEnumToBits
+                                            $ pageOperations ]
+ <> mconcat [ BB.word64LE w64 | BlobRef w64 _w32 <- pageBlobRefs ]
+ <> mconcat [ BB.word32LE w32 | BlobRef _w64 w32 <- pageBlobRefs ]
+ <> mconcat [ BB.word16LE off | off <- pageKeyOffsets ]
+ <> case pageValueOffsets of
+      Left   offsets -> mconcat [ BB.word16LE off | off <- offsets ]
+      Right (offset1, offset2) -> BB.word16LE offset1
+                               <> BB.word32LE offset2
+ <> BB.byteString pageKeys
+ <> BB.byteString pageValues
+  where
+    opEnumToBits OpInsert  = [False, False]
+    opEnumToBits OpMupsert = [True,  False]
+    opEnumToBits OpDelete  = [False, True]
+
+deserialisePage :: PageSerialised -> PageIntermediate
+deserialisePage p =
+    flip Bin.runGet (BSL.fromStrict p) $ do
+      pageNumKeys       <- Bin.getWord16le
+      pageNumBlobs      <- Bin.getWord16le
+      offsetKeyOffsets  <- Bin.getWord16le
+      _                 <- Bin.getWord16le
+
+      let sizeWord64BlobRefBitmap :: Int
+          sizeWord64BlobRefBitmap = (fromIntegral pageNumKeys + 63) `shiftR` 6
+
+          sizeWord64Operations :: Int
+          sizeWord64Operations = (fromIntegral (2 * pageNumKeys) + 63) `shiftR` 6
+
+      pageBlobRefBitmap <- take (fromIntegral pageNumKeys) . fromBitmap <$>
+                             replicateM sizeWord64BlobRefBitmap Bin.getWord64le
+      pageOperations    <- take (fromIntegral pageNumKeys)
+                         . opBitsToEnum . fromBitmap <$>
+                             replicateM sizeWord64Operations Bin.getWord64le
+      pageBlobRefsW64   <- replicateM (fromIntegral pageNumBlobs) Bin.getWord64le
+      pageBlobRefsW32   <- replicateM (fromIntegral pageNumBlobs) Bin.getWord32le
+      let pageBlobRefs   = zipWith BlobRef pageBlobRefsW64 pageBlobRefsW32
+
+      pageKeyOffsets    <- replicateM (fromIntegral pageNumKeys) Bin.getWord16le
+      pageValueOffsets  <-
+        if pageNumKeys == 1
+         then Right <$> ((,) <$> Bin.getWord16le
+                             <*> Bin.getWord32le)
+         else Left <$> replicateM (fromIntegral pageNumKeys + 1) Bin.getWord16le
+
+      let sizeKeys :: Word16
+          sizeKeys
+            | pageNumKeys > 0
+            = either head fst pageValueOffsets
+              - head pageKeyOffsets
+            | otherwise       = 0
+
+          sizeValues :: Word32
+          sizeValues
+            | pageNumKeys > 0
+            = either (fromIntegral . last) snd pageValueOffsets
+              - fromIntegral (either head fst pageValueOffsets)
+            | otherwise = 0
+      pageKeys   <- Bin.getByteString (fromIntegral sizeKeys)
+      pageValues <- Bin.getByteString (fromIntegral sizeValues)
+
+      let pageSizesOffsets = calcPageSizeOffsets
+                               pageNumKeys pageNumBlobs
+                               sizeKeys sizeValues
+
+      assert (offsetKeyOffsets == offKeyOffsets pageSizesOffsets) $
+        return PageIntermediate{..}
+  where
+    opBitsToEnum (False:False:bits) = OpInsert  : opBitsToEnum bits
+    opBitsToEnum (True: False:bits) = OpMupsert : opBitsToEnum bits
+    opBitsToEnum (False:True :bits) = OpDelete  : opBitsToEnum bits
+    opBitsToEnum []                 = []
+    opBitsToEnum _                  = error "opBitsToEnum"
+
+decodePage :: PageIntermediate -> PageLogical
+decodePage PageIntermediate{pageSizesOffsets = PageSizesOffsets{..}, ..} =
+  PageLogical
+    [ let op      = case opEnum of
+                      OpInsert  -> Insert  (Value value)
+                      OpMupsert -> Mupsert (Value value)
+                      OpDelete  -> Delete
+          mblobref | hasBlobref = Just (pageBlobRefs !! idxBlobref)
+                   | otherwise  = Nothing
+       in (Key key, op, mblobref)
+    | opEnum     <- pageOperations
+    | hasBlobref <- pageBlobRefBitmap
+    | idxBlobref <- scanl (\o b -> if b then o+1 else o) 0 pageBlobRefBitmap
+    | keySpan    <- spans $ pageKeyOffsets
+                         ++ either (take 1) ((:[]) . fst) pageValueOffsets
+    , let key     = BS.take (fromIntegral $ snd keySpan - fst keySpan)
+                  . BS.drop (fromIntegral $ fst keySpan - offKeys)
+                  $ pageKeys
+    | valSpan    <- spans $ case pageValueOffsets of
+                              Left offs          -> map fromIntegral offs
+                              Right (off1, off2) -> [ fromIntegral off1, off2 ]
+    , let value   = BS.take (fromIntegral $ snd valSpan - fst valSpan)
+                  . BS.drop (fromIntegral $ fst valSpan - fromIntegral offValues)
+                  $ pageValues
+
+    ]
+  where
+    spans xs = zip xs (drop 1 xs)
+
+
+toBitmap :: [Bool] -> [Word64]
+toBitmap =
+    map toWord64 . group64
+  where
+    toWord64 :: [Bool] -> Word64
+    toWord64 = foldl' (\w (n,b) -> if b then setBit w n else w) 0
+             . zip [0 :: Int ..]
+    group64  = unfoldr (\xs -> if null xs
+                                 then Nothing
+                                 else Just (splitAt 64 xs))
+
+fromBitmap :: [Word64] -> [Bool]
+fromBitmap =
+    concatMap fromWord64
+  where
+    fromWord64 :: Word64 -> [Bool]
+    fromWord64 w = [ testBit w i | i <- [0..63] ]
+
+tests :: TestTree
+tests = testGroup "FormatPage" [
+      testProperty "to/from bitmap" prop_toFromBitmap
+    , testProperty "size distribution" prop_size_distribution
+    , testProperty "size 1" prop_size1
+    , testProperty "size 2" prop_size2
+    , testProperty "size 3" prop_size3
+    , testProperty "encode/decode" prop_encodeDecode
+    , testProperty "serialise/deserialise" prop_serialiseDeserialise
+    , testProperty "encode/serialise/deserialise/decode"
+                   prop_encodeSerialiseDeserialiseDecode
+    ]
+
+
+prop_toFromBitmap :: [Bool] -> Bool
+prop_toFromBitmap bits =
+    bits == take (length bits) (roundTrip bits)
+  where
+    roundTrip = fromBitmap . toBitmap
+
+prop_encodeDecode :: PageLogical -> Bool
+prop_encodeDecode p =
+    p == roundTrip p
+  where
+    roundTrip = decodePage . encodePage
+
+prop_size_distribution :: PageLogical -> Property
+prop_size_distribution p@(PageLogical es) =
+  case calcPageSize p of
+    Nothing -> property False
+    Just PageSize{pageSizeElems, pageSizeBlobs, pageSizeBytes} ->
+      tabulate "page size in elements"
+        [ showNumElems pageSizeElems ] $
+      tabulate "page number of blobs"
+        [ showNumElems pageSizeBlobs ] $
+      tabulate "page size in bytes"
+        [ showPageSizeBytes pageSizeBytes ] $
+      tabulate "key size in bytes"
+        [ showKeyValueSizeBytes (BS.length k) | (Key k, _, _) <- es ] $
+      tabulate "value size in bytes"
+        [ showKeyValueSizeBytes (BS.length v)
+        | (_, op, _) <- es
+        , Value v <- case op of
+                       Insert  v -> [v]
+                       Mupsert v -> [v]
+                       Delete    -> []
+        ] $
+      cover 0.5 (pageSizeBytes > 4096) "page over 4k" $
+
+        property $ (if pageSizeElems > 1
+                       then pageSizeBytes <= 4096
+                       else True)
+                && (pageSizeElems == length [ e | e <- es ])
+                && (pageSizeBlobs == length [ b | (_,_,Just b) <- es ])
+  where
+    showNumElems n
+      | n == 0    = "0"
+      | n == 1    = "1"
+      | n < 10    = "1 < n < 10"
+      | otherwise = nearest 10 n
+    showPageSizeBytes n
+      | n >= 4096  = show ((n `div` 4096) * 4) ++ "k <= n < "
+                  ++ show (((n `div` 4096) + 1) * 4) ++ "k"
+      | otherwise = nearest 512 n
+    showKeyValueSizeBytes n
+      | n < 16    = show n
+      | n < 1024  = "16    < n < 1024"
+      | otherwise = nearest 1024 n
+    nearest m n = show ((n `div` m) * m)
+     ++ " <= n < " ++ show ((n `div` m) * m + m)
+
+prop_size1 :: PageLogical -> Bool
+prop_size1 p =
+    BS.length (serialisePage p')
+ == fromIntegral (sizePageTotal (pageSizesOffsets p'))
+  where
+    p' = encodePage p
+
+prop_size2 :: PageLogical -> Bool
+prop_size2 p =
+  case calcPageSize p of
+    Nothing   -> True
+    Just PageSize{pageSizeBytes} ->
+      pageSizeBytes == (fromIntegral . sizePageTotal
+                      . pageSizesOffsets . encodePage) p
+
+prop_size3 :: PageLogical -> Bool
+prop_size3 p =
+  case calcPageSize p of
+    Nothing                      -> True
+    Just PageSize{pageSizeBytes} ->
+      pageSizeBytes == BS.length (serialisePage (encodePage p))
+
+prop_serialiseDeserialise :: PageLogical -> Bool
+prop_serialiseDeserialise p =
+    p' == roundTrip p'
+  where
+    p'        = encodePage p
+    roundTrip = deserialisePage . serialisePage
+
+prop_encodeSerialiseDeserialiseDecode :: PageLogical -> Bool
+prop_encodeSerialiseDeserialiseDecode p =
+    p == roundTrip p
+  where
+    roundTrip = decodePage . deserialisePage . serialisePage . encodePage
+
+maxKeySize :: Int
+maxKeySize = 4096 - overhead  -- 4052
+  where
+    overhead =
+      (pageSizeBytes . fromJust . calcPageSize . PageLogical)
+        [(Key BS.empty, Delete, Just (BlobRef 0 0))]
+
+instance Arbitrary Key where
+  arbitrary = do
+    sz <- getSize
+    n  <- chooseInt (0, sz `min` maxKeySize)
+    Key . BS.pack <$> vectorOf n arbitrary
+
+  shrink (Key k) = [ Key (BS.pack k') | k' <- shrink (BS.unpack k) ]
+
+instance Arbitrary Value where
+  arbitrary = do
+    sz <- getSize
+    n  <- chooseInt (0, sz)
+    Value . BS.pack <$> vectorOf n arbitrary
+
+  shrink (Value v) = [ Value (BS.pack v') | v' <- shrink (BS.unpack v) ]
+
+instance Arbitrary Operation where
+  arbitrary =
+    oneof
+      [ Insert  <$> arbitrary
+      , Mupsert <$> arbitrary
+      , pure Delete
+      ]
+
+  shrink Delete      = []
+  shrink (Insert v)  = Delete   : [ Insert  v' | v' <- shrink v ]
+  shrink (Mupsert v) = Insert v : [ Mupsert v' | v' <- shrink v ]
+
+instance Arbitrary BlobRef where
+  arbitrary = BlobRef <$> arbitrary <*> arbitrary
+
+  shrink (BlobRef w64 w32) =
+      [ BlobRef w64' w32' | (w64', w32') <- shrink (w64, w32) ]
+
+instance Arbitrary PageLogical where
+  arbitrary =
+    frequency
+      [ (1, (PageLogical . (:[])) <$>
+               scale (\n' -> ceiling (fromIntegral n' ** 1.8 :: Float)) arbitrary)
+      , (4, do n <- getSize
+               scale (\n' -> ceiling (sqrt (fromIntegral n' :: Float))) $
+                 go [] n pageSizeEmpty)
+      ]
+    where
+      go es 0 _  = return (PageLogical (sortBy (compare `on` (\(k,_,_)->k)) es))
+      go es i sz = do
+        e <- arbitrary
+        case pageSizeAddElem e sz of
+          Nothing  -> return (PageLogical es)
+          Just sz' -> go (e:es) (i-1) sz'
+
+  shrink (PageLogical p) =
+    [ PageLogical p' | p' <- shrink p ]
+

--- a/prototypes/Test.hs
+++ b/prototypes/Test.hs
@@ -2,9 +2,11 @@ module Main (main) where
 
 import           Test.Tasty
 
+import qualified FormatPage
 import qualified ScheduledMergesTestQLS
 
 main :: IO ()
 main = defaultMain $ testGroup "prototype" [
-      ScheduledMergesTestQLS.tests
+      ScheduledMergesTestQLS.tests,
+      FormatPage.tests
     ]


### PR DESCRIPTION
Covering the outline for all three documents:
 * `format-directory.md`: covering the overall LSM directory format
 * `format-run.md`: covering the LSM file-run format
 * `format-page.md`: covering the LSM file-run _page_ format

And filling in most of the details for the page format documentation.

Also, add a reference implementation and test for the page format.

Covers encoding/decoding and calculating the expected page size
while accumuating key/operation pairs. Includes tests for the usual
round trip properties, and checking size and offset calculations.

This should be the basis for high performance (de)serialisation and
intra-page lookup implementations.