### PR TITLE
Fix bit slicing on big-endian systems, drop `ghc-8.10.7`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,14 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.8", "9.4.7", "9.6.3"]
+        ghc: ["9.2.8", "9.4.7", "9.6.3"]
         cabal: ["3.10.1.0"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
-          - ghc: "9.2.8"
-            os: windows-latest
-          - ghc: "9.2.8"
-            os: macOS-latest
           - ghc: "9.4.7"
             os: windows-latest
           - ghc: "9.4.7"

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -11,7 +11,7 @@ copyright:          2023 Input Output Global Inc (IOG)
 category:           Database
 build-type:         Simple
 extra-doc-files:    CHANGELOG.md
-tested-with:        GHC ==8.10 || ==9.2 || ==9.4 || ==9.6
+tested-with:        GHC ==9.2 || ==9.4 || ==9.6
 extra-source-files:
   bloomfilter/cbits/lookup3.c
   bloomfilter/cbits/lookup3.h
@@ -48,7 +48,7 @@ library
     Database.LSMTree.Normal
 
   build-depends:
-    , base                  >=4.14  && <4.19
+    , base                  >=4.16  && <4.19
     , bitvec                ^>=1.1
     , bytestring
     , containers
@@ -139,7 +139,7 @@ test-suite lsm-tree-test
     Test.Util.TypeFamilyWrappers
 
   build-depends:
-    , base                                 >=4.14 && <4.19
+    , base                                 >=4.16 && <4.19
     , bytestring
     , constraints
     , containers
@@ -213,7 +213,7 @@ test-suite kmerge-test
   hs-source-dirs:   test
   main-is:          kmerge-test.hs
   build-depends:
-    , base              >=4.14 && <4.19
+    , base              >=4.16 && <4.19
     , deepseq
     , heaps
     , lsm-tree:kmerge
@@ -231,7 +231,7 @@ test-suite map-range-test
   hs-source-dirs:   test
   main-is:          map-range-test.hs
   build-depends:
-    , base              >=4.14 && <4.19
+    , base              >=4.16 && <4.19
     , bytestring
     , containers
     , lsm-tree


### PR DESCRIPTION
Resolves:
* https://github.com/input-output-hk/lsm-tree/pull/38#discussion_r1432675545
* https://github.com/input-output-hk/lsm-tree/pull/38#discussion_r1432683685