### PR TITLE
Move Entry to its own module

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -35,6 +35,7 @@ library
     Data.Map.Range
     Database.LSMTree.Common
     Database.LSMTree.Internal.BlobRef
+    Database.LSMTree.Internal.Entry
     Database.LSMTree.Internal.Integration
     Database.LSMTree.Internal.KMerge
     Database.LSMTree.Internal.Monoidal

--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE DeriveTraversable #-}
+module Database.LSMTree.Internal.Entry (
+    Entry (..),
+) where
+
+data Entry v blobref
+    = Insert !v
+    | InsertWithBlob !v !blobref
+    | Mupdate !v
+    | Delete
+  deriving (Show, Functor, Foldable, Traversable)

--- a/src/Database/LSMTree/Internal/WriteBuffer.hs
+++ b/src/Database/LSMTree/Internal/WriteBuffer.hs
@@ -33,19 +33,13 @@ import qualified Data.Map.Range as Map.R
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Database.LSMTree.Common (Range (..))
+import           Database.LSMTree.Internal.Entry
 import qualified Database.LSMTree.Internal.Monoidal as Monoidal
 import qualified Database.LSMTree.Internal.Normal as Normal
 
 {-------------------------------------------------------------------------------
   Writebuffer type
 -------------------------------------------------------------------------------}
-
-data Entry v blobref
-    = Insert !v
-    | InsertWithBlob !v !blobref
-    | Mupdate !v
-    | Delete
-  deriving (Show, Functor, Foldable, Traversable)
 
 newtype WriteBuffer k v blobref = WB (Map k (Entry v blobref))
 


### PR DESCRIPTION
Other stuff may need `Entry` type (e.g. rawpage lookup would/could return it as well).