### PR TITLE
Benchmark tree building shouldn't access environment variables

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Integration.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Integration.hs
@@ -68,7 +68,7 @@ benchmarks = bgroup "Bench.Database.LSMTree.Internal.Integration" [
     benchPrepLookups conf@Config{name} =
       env (prepLookupsEnv (Proxy @UTxOKey) conf) $ \ ~(b, ci, ks) ->
         -- see 'npages'.
-        bgroup (printf "%s, %d actual pages" name (Index.sizeInPages ci)) [
+        bgroup (printf "%s, ? actual pages" name) [
             -- the bloomfilter is queried for all lookup keys
             bench "Bloomfilter query"    $ whnf (elems b) ks
             -- the compact index is only searched for (true and false) positive


### PR DESCRIPTION
Otherwise `--list` doesn't work.

I'm surprised that filtering works, i.e. that `criterion` makes proper environments *before* figuring out what to do. `tasty(-bench)` doesn't do so IIRC, i.e. expensive environments are not built if aren't needed.