### PR TITLE
rawPageEntry micro benchmark

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications   #-}
+
+
+module Bench.Database.LSMTree.Internal.RawPage (
+    benchmarks
+    -- * Benchmarked functions
+  ) where
+
+import           Control.DeepSeq (deepseq)
+import           Criterion.Main
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
+import           Data.Primitive.ByteArray (ByteArray (..))
+import qualified Data.Vector.Primitive as P
+import           Data.Word (Word8)
+import           Database.LSMTree.Internal.RawPage
+import           Database.LSMTree.Util.Orphans ()
+import           FormatPage
+import           Test.QuickCheck
+import           Test.QuickCheck.Gen (Gen (..))
+import           Test.QuickCheck.Random (mkQCGen)
+
+benchmarks :: Benchmark
+benchmarks = rawpage `deepseq` bgroup "Bench.Database.LSMTree.Internal.RawPage"
+    [ bench "missing" $ nf (rawPageEntry rawpage) missing
+    , bench "existing-head" $ nf (rawPageEntry rawpage) existingHead
+    , bench "existing-last" $ nf (rawPageEntry rawpage) existingLast
+    ]
+  where
+    page :: PageLogical
+    page = unGen (genFullPageLogical genSmallKey genSmallValue) (mkQCGen 42) 200
+
+    rawpage :: RawPage
+    rawpage = fst $ toRawPage $ page
+
+    genSmallKey :: Gen Key
+    genSmallKey = Key . BS.pack <$> vectorOf 8 arbitrary
+
+    genSmallValue :: Gen Value
+    genSmallValue = Value . BS.pack <$> vectorOf 8 arbitrary
+
+    missing :: P.Vector Word8
+    missing = P.fromList [1, 2, 3]
+
+    keys :: [Key]
+    keys = case page of
+        PageLogical xs -> map (\(k,_,_) -> k) xs
+
+    existingHead :: P.Vector Word8
+    existingHead = bsToVector $ unKey $ head keys
+
+    existingLast :: P.Vector Word8
+    existingLast = bsToVector $ unKey $ last keys
+
+toRawPage :: PageLogical -> (RawPage, BS.ByteString)
+toRawPage p = (page, sfx)
+  where
+    bs = serialisePage $ encodePage p
+    (pfx, sfx) = BS.splitAt 4096 bs -- hardcoded page size.
+    page = case SBS.toShort pfx of SBS.SBS ba -> makeRawPage (ByteArray ba) 0
+
+bsToVector :: BS.ByteString -> P.Vector Word8
+bsToVector = P.fromList . BS.unpack

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -10,6 +10,7 @@
 module Main (main) where
 
 import qualified Bench.Database.LSMTree.Internal.Integration
+import qualified Bench.Database.LSMTree.Internal.RawPage
 import qualified Bench.Database.LSMTree.Internal.Run.BloomFilter
 import qualified Bench.Database.LSMTree.Internal.Run.Index.Compact
 import           Criterion.Main (defaultMain)
@@ -19,4 +20,5 @@ main = defaultMain [
       Bench.Database.LSMTree.Internal.Integration.benchmarks
     , Bench.Database.LSMTree.Internal.Run.BloomFilter.benchmarks
     , Bench.Database.LSMTree.Internal.Run.Index.Compact.benchmarks
+    , Bench.Database.LSMTree.Internal.RawPage.benchmarks
     ]

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -54,6 +54,7 @@ library
     , bitvec                ^>=1.1
     , bytestring
     , containers
+    , deepseq
     , filepath
     , fs-api                ^>=0.2
     , io-classes            ^>=1.2
@@ -176,18 +177,22 @@ benchmark lsm-tree-micro-bench
   main-is:          Main.hs
   other-modules:
     Bench.Database.LSMTree.Internal.Integration
+    Bench.Database.LSMTree.Internal.RawPage
     Bench.Database.LSMTree.Internal.Run.BloomFilter
     Bench.Database.LSMTree.Internal.Run.Index.Compact
 
   build-depends:
     , base
+    , bytestring
     , containers
     , criterion
     , deepseq
     , extra
-    , lsm-tree:{lsm-tree, bloomfilter, lsm-tree-utils}
+    , lsm-tree:{lsm-tree, bloomfilter, lsm-tree-utils, prototypes}
+    , primitive
     , QuickCheck
     , random
+    , vector
 
 benchmark lsm-tree-macro-bench
   import:           warnings

--- a/src/Database/LSMTree/Internal/Entry.hs
+++ b/src/Database/LSMTree/Internal/Entry.hs
@@ -3,9 +3,17 @@ module Database.LSMTree.Internal.Entry (
     Entry (..),
 ) where
 
+import           Control.DeepSeq (NFData (..))
+
 data Entry v blobref
     = Insert !v
     | InsertWithBlob !v !blobref
     | Mupdate !v
     | Delete
   deriving (Eq, Show, Functor, Foldable, Traversable)
+
+instance (NFData v, NFData blobref) => NFData (Entry v blobref) where
+    rnf (Insert v)            = rnf v
+    rnf (InsertWithBlob v br) = rnf v `seq` rnf br
+    rnf (Mupdate v)           = rnf v
+    rnf Delete                = ()

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -18,6 +18,7 @@ module Database.LSMTree.Internal.RawPage (
     rawPageValues,
 ) where
 
+import           Control.DeepSeq (NFData (rnf))
 import           Data.Bits (Bits, complement, popCount, unsafeShiftL,
                      unsafeShiftR, (.&.))
 import           Data.Primitive.ByteArray (ByteArray (..), indexByteArray,
@@ -36,6 +37,9 @@ data RawPage = RawPage
     !Int        -- ^ offset in Word16s.
     !ByteArray
   deriving (Show)
+
+instance NFData RawPage where
+  rnf (RawPage _ _) = ()
 
 -- | This instance assumes pages are 4096 bytes in size
 instance Eq RawPage where

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE BangPatterns    #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE NamedFieldPuns #-}
 module Database.LSMTree.Internal.RawPage (
     RawPage,
     makeRawPage,
@@ -65,8 +65,7 @@ rawPageEntry
     -> Maybe (Entry (P.Vector Word8) (Word64, Word32))
 rawPageEntry !page !key = bisect 0 (fromIntegral dirNumKeys)
   where
-    --TODO: these Dir values don't unbox properly:
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
 
     -- when to switch to linear scan
     -- this a tuning knob
@@ -117,21 +116,28 @@ rawPageNumKeys (RawPage off ba) = indexByteArray ba off
 rawPageNumBlobs :: RawPage -> Word16
 rawPageNumBlobs (RawPage off ba) = indexByteArray ba (off + 1)
 
+rawPageKeysOffset :: RawPage -> Word16
+rawPageKeysOffset (RawPage off ba) = indexByteArray ba (off + 2)
+
 type KeyOffset = Word16
 type ValueOffset = Word16
 
 rawPageKeyOffsets :: RawPage -> P.Vector KeyOffset
 rawPageKeyOffsets page@(RawPage off ba) =
-    P.Vector (off + fromIntegral (div2 dirOffset)) (fromIntegral dirNumKeys + 1) ba
+    P.Vector (off + fromIntegral (div2 dirOffset))
+             (fromIntegral dirNumKeys + 1) ba
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
+    !dirOffset  = rawPageKeysOffset page
 
 -- | for non-single key page case
 rawPageValueOffsets :: RawPage -> P.Vector ValueOffset
 rawPageValueOffsets page@(RawPage off ba) =
-    P.Vector (off + fromIntegral (div2 dirOffset) + fromIntegral dirNumKeys) (fromIntegral dirNumKeys + 1) ba
+    P.Vector (off + fromIntegral (div2 dirOffset) + fromIntegral dirNumKeys)
+             (fromIntegral dirNumKeys + 1) ba
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
+    !dirOffset  = rawPageKeysOffset page
 
 -- | single key page case
 rawPageValueOffsets1 :: RawPage -> (Word16, Word32)
@@ -140,7 +146,7 @@ rawPageValueOffsets1 page@(RawPage off ba) =
     , indexByteArray ba (div2 (off + fromIntegral (div2 dirOffset)) + 1)
     )
   where
-    Dir {..} = rawPageDirectory page
+    !dirOffset = rawPageKeysOffset page
 
 rawPageHasBlobRefAt :: RawPage -> Int -> Word64
 rawPageHasBlobRefAt _page@(RawPage off ba) i = do
@@ -156,7 +162,7 @@ rawPageOpAt page@(RawPage off ba) i = do
     let word = indexByteArray ba (div4 off + 1 + roundUpTo64 (fromIntegral dirNumKeys) + j)
     unsafeShiftR word (mul2 k) .&. 3
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
 
 roundUpTo64 :: Int -> Int
 roundUpTo64 i = unsafeShiftR (i + 63) 6
@@ -171,7 +177,7 @@ rawPageKeys page@(RawPage off ba) = do
         , let end   = fromIntegral (P.unsafeIndex offs (i + 1)) :: Int
         ]
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
 
 rawPageKeyAt :: RawPage -> Int -> P.Vector Word8
 rawPageKeyAt page@(RawPage off ba) i = do
@@ -192,7 +198,7 @@ rawPageValues page@(RawPage off ba) = do
         , let end   = fromIntegral (P.unsafeIndex offs (i + 1)) :: Int
         ]
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys = rawPageNumKeys page
 
 rawPageValueAt :: RawPage -> Int -> P.Vector Word8
 rawPageValueAt page@(RawPage off ba) i = do
@@ -220,7 +226,8 @@ rawPageBlobRefIndex page@(RawPage off ba) i =
     , indexByteArray ba (off2 + i)
     )
   where
-    Dir {..} = rawPageDirectory page
+    !dirNumKeys  = rawPageNumKeys page
+    !dirNumBlobs = rawPageNumBlobs page
 
     -- offset to start of blobrefs arr
     off1 = div4 off + 1 + roundUpTo64 (fromIntegral dirNumKeys) + roundUpTo64 (fromIntegral (mul2 dirNumKeys))
@@ -237,22 +244,6 @@ rawPageCalculateBlobIndex (RawPage off ba) i = do
     let s = foldl' (+) 0 [ popCount (indexByteArray ba (div4 off + 1 + jj) :: Word64) | jj <- [0 .. j-1 ] ]
     let word = indexByteArray ba (div4 off + 1 + j) :: Word64
     s + popCount (word .&. complement (unsafeShiftL 0xffffffffffffffff k))
-
--------------------------------------------------------------------------------
--- Directory
--------------------------------------------------------------------------------
-
-data Directory = Dir
-    { dirNumKeys  :: !Word16
-    , dirNumBlobs :: !Word16
-    , dirOffset   :: !Word16
-    }
-
-rawPageDirectory :: RawPage -> Directory
-rawPageDirectory (RawPage off ba) = Dir
-    (indexByteArray ba off)
-    (indexByteArray ba (off + 1))
-    (indexByteArray ba (off + 2))
 
 -------------------------------------------------------------------------------
 -- Utils


### PR DESCRIPTION
Benchmark results on my machine look like:

```
benchmarking Bench.Database.LSMTree.Internal.RawPage/missing
time                 104.7 ns   (100.8 ns .. 109.5 ns)
variance introduced by outliers: 78% (severely inflated)

benchmarking Bench.Database.LSMTree.Internal.RawPage/existing-head
time                 266.0 ns   (264.0 ns .. 269.2 ns)

benchmarking Bench.Database.LSMTree.Internal.RawPage/existing-last
time                 288.4 ns   (271.6 ns .. 304.0 ns)
```

looking up the first or last element is virtually the same,
as it should be when using bisecting.

missing being faster than existing element is explainable by the
overhead of actually looking up all the other associated data
(in the generated benchmark input both first and last elements have blobref)

And the algorithmic complexity is visible, e.g. if we lookup linearly,
then looking up head is fast, last is slow, missing is slow too:

```
benchmarking Bench.Database.LSMTree.Internal.RawPage/missing
time                 764.5 ns   (757.2 ns .. 773.0 ns)

benchmarking Bench.Database.LSMTree.Internal.RawPage/existing-head
time                 178.2 ns   (172.1 ns .. 184.3 ns)

benchmarking Bench.Database.LSMTree.Internal.RawPage/existing-last
time                 3.031 μs   (2.825 μs .. 3.227 μs)
```