### PR TITLE
Make `SerialisedKey` sliceable

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -51,9 +51,9 @@ library
     Database.LSMTree.Normal
 
   build-depends:
-    , base                  >=4.16  && <4.19
+    , base                  >=4.16      && <4.19
     , bitvec                ^>=1.1
-    , bytestring
+    , bytestring            ^>=0.11.4.0
     , containers
     , deepseq
     , filepath
@@ -109,7 +109,6 @@ library lsm-tree-utils
     , containers
     , deepseq
     , lsm-tree:{lsm-tree, bloomfilter}
-    , primitive
     , QuickCheck
     , random
     , wide-word
@@ -133,6 +132,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.Run.BloomFilter
     Test.Database.LSMTree.Internal.Run.Construction
     Test.Database.LSMTree.Internal.Run.Index.Compact
+    Test.Database.LSMTree.Internal.Serialise
     Test.Database.LSMTree.Model.Monoidal
     Test.Database.LSMTree.Model.Normal
     Test.Database.LSMTree.ModelIO.Class
@@ -145,9 +145,9 @@ test-suite lsm-tree-test
     Test.Util.TypeFamilyWrappers
 
   build-depends:
-    , base                                             >=4.16      && <4.19
+    , base                                             >=4.16 && <4.19
     , bitvec
-    , bytestring                                       ^>=0.11.4.0
+    , bytestring
     , constraints
     , containers
     , cryptohash-sha256

--- a/src/Database/LSMTree/Internal/Run/Construction.hs
+++ b/src/Database/LSMTree/Internal/Run/Construction.hs
@@ -50,11 +50,13 @@ import           Data.Foldable (Foldable (..))
 import           Data.Maybe (fromMaybe)
 import           Data.Monoid (Dual (..))
 import           Data.Primitive.ByteArray (ByteArray (..), sizeofByteArray)
+import qualified Data.Vector.Primitive as P
 import           Data.Word (Word16, Word32, Word64, Word8)
 import           Database.LSMTree.Internal.Entry (Entry (..), onBlobRef,
                      onValue)
-import           Database.LSMTree.Internal.Serialise (SerialisedKey,
-                     sizeofKey16, sizeofKey64, toShortByteString, topBits16)
+import           Database.LSMTree.Internal.Serialise
+                     (SerialisedKey (SerialisedKey), sizeofKey16, sizeofKey64,
+                     topBits16)
 import           Foreign.Ptr (minusPtr, plusPtr)
 
 {-------------------------------------------------------------------------------
@@ -173,7 +175,8 @@ pageBuilder PageAcc{..} =
       vs  -> Left (scanr (\v o -> o + sizeofValue16 v) offValues vs)
 
     rawKey :: SerialisedKey -> BB.Builder
-    rawKey = BB.shortByteString . toShortByteString
+    rawKey (SerialisedKey (P.Vector off size (ByteArray ba#))) =
+        shortByteStringFromTo off (off + size) (SBS ba#)
 
     rawValue :: RawValue -> BB.Builder
     rawValue EmptyRawValue                  = mempty

--- a/src/Database/LSMTree/Internal/Serialise.hs
+++ b/src/Database/LSMTree/Internal/Serialise.hs
@@ -18,23 +18,22 @@ module Database.LSMTree.Internal.Serialise (
   , sizeofKey
   , sizeofKey16
   , sizeofKey64
-  , toShortByteString
   , fromShortByteString
   ) where
 
+import           Control.Exception (assert)
 import           Data.Bits (Bits (shiftL, shiftR))
+import           Data.BloomFilter.Hash (hashList32)
+import           Data.ByteString.Short (ShortByteString (SBS))
 import qualified Data.ByteString.Short as SBS
-import           Data.ByteString.Short.Internal (ShortByteString (SBS))
 import           Data.Kind (Type)
-import           Data.Primitive.ByteArray (ByteArray (..), sizeofByteArray)
+import           Data.Primitive.ByteArray
+import qualified Data.Vector.Primitive as P
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           GHC.Exts
 import           GHC.Word
 
 -- | Serialisation into a 'SerialisedKey' (i.e., a 'ByteArray').
---
--- Comparison of @a@-values should be preserved by serialisation. Note that
--- 'SerialisedKey's are lexicographically ordered.
 --
 -- INVARIANT: Serialisation should preserve ordering, @x `compare` y ==
 -- serialise x `compare` serialise y@. Serialised keys are lexicographically
@@ -43,24 +42,42 @@ import           GHC.Word
 class Serialise a where
   serialise :: a -> SerialisedKey
 
--- | A first attempt at a representation for a serialised key.
+-- | Representation of a serialised key.
 --
 -- Serialisation should preserve equality and ordering. The 'Ord' instance for
 -- 'SerialisedKey' uses lexicographical ordering.
 type SerialisedKey :: Type
-newtype SerialisedKey = SerialisedKey ByteArray
-  deriving newtype (Show, Eq)
+newtype SerialisedKey = SerialisedKey (P.Vector Word8)
+  deriving newtype (Show)
 
--- | Re-use lexicographical 'Ord' instance from 'ShortByteString'.
+instance Eq SerialisedKey where
+  k1 == k2 = compareBytes k1 k2 == EQ
+
+-- | Lexicographical 'Ord' instance.
 instance Ord SerialisedKey where
-  (SerialisedKey (ByteArray skey1#)) `compare` (SerialisedKey (ByteArray skey2#)) =
-      SBS skey1# `compare` SBS skey2#
+  compare = compareBytes
 
--- TODO: optimisation
+-- | Based on @Ord 'ShortByteString'@.
+compareBytes :: SerialisedKey -> SerialisedKey -> Ordering
+compareBytes k1@(SerialisedKey vec1) k2@(SerialisedKey vec2) =
+    let !len1 = sizeofKey k1
+        !len2 = sizeofKey k2
+        !len  = min len1 len2
+     in case compareByteArrays ba1 off1 ba2 off2 len of
+          EQ | len2 > len1 -> LT
+             | len2 < len1 -> GT
+          o  -> o
+  where
+    P.Vector off1 _size1 ba1 = vec1
+    P.Vector off2 _size2 ba2 = vec2
+
 instance Hashable SerialisedKey where
   hashIO32 :: SerialisedKey -> Word32 -> IO Word32
-  hashIO32 (SerialisedKey (ByteArray ba#)) =
-    hashIO32 (SBS.fromShort $ SBS ba#)
+  hashIO32 = hashBytes
+
+-- TODO: optimisation
+hashBytes :: SerialisedKey -> Word32 -> IO Word32
+hashBytes (SerialisedKey vec) = hashList32 (P.toList vec)
 
 -- | @'topBits16' n k@ slices the first @n@ bits from the /top/ of the
 -- serialised key @k@. Returns the string of bits as a 'Word16'.
@@ -76,9 +93,10 @@ instance Hashable SerialisedKey where
 -- core, find other opportunities for using primops.
 --
 topBits16 :: Int -> SerialisedKey -> Word16
-topBits16 n (SerialisedKey (ByteArray k#)) = shiftR w16 (16 - n)
+topBits16 n k@(SerialisedKey (P.Vector (I# off#) _size (ByteArray k#))) =
+    assert (sizeofKey k >= 2) $ shiftR w16 (16 - n)
   where
-    w16 = toWord16 (indexWord8ArrayAsWord16# k# 0#)
+    w16 = toWord16 (indexWord8ArrayAsWord16# k# off#)
 
 toWord16 :: Word16# -> Word16
 #if WORDS_BIGENDIAN
@@ -105,15 +123,18 @@ toWord16 x# = byteSwap16 (W16# x#)
 -- core, find other opportunities for using primops.
 --
 sliceBits32 :: Int -> SerialisedKey -> Word32
-sliceBits32 (I# off#) (SerialisedKey (ByteArray k#))
+sliceBits32 off@(I# off1#) k@(SerialisedKey (P.Vector (I# off2#) _size (ByteArray k#)))
     | 0# <- r#
-    =   toWord32 (indexWord8ArrayAsWord32# k# q#)
+    = assert (off + 32 <= 8 * sizeofKey k) $
+      toWord32 (indexWord8ArrayAsWord32# k# q#)
     | otherwise
-    =   toWord32 (indexWord8ArrayAsWord32# k# q#        ) `shiftL` r
+    = assert (off + 32 <= 8 * sizeofKey k) $
+        toWord32 (indexWord8ArrayAsWord32# k# q#       ) `shiftL` r
       + w8w32#   (indexWord8Array#         k# (q# +# 4#)) `shiftR` (8 - r)
   where
-    !(# q#, r# #) = quotRemInt# off# 8#
-    r             = I# r#
+    !(# q0#, r# #) = quotRemInt# off1# 8#
+    !q#            = q0# +# off2#
+    r              = I# r#
     -- No need for byteswapping here
     w8w32# x#     = W32# (wordToWord32# (word8ToWord# x#))
 
@@ -126,7 +147,7 @@ toWord32 x# = byteSwap32 (W32# x#)
 
 -- | Size of key in number of bytes.
 sizeofKey :: SerialisedKey -> Int
-sizeofKey (SerialisedKey ba) = sizeofByteArray ba
+sizeofKey (SerialisedKey pvec) = P.length pvec
 
 -- | Size of key in number of bytes.
 sizeofKey16 :: SerialisedKey -> Word16
@@ -136,8 +157,6 @@ sizeofKey16 = fromIntegral . sizeofKey
 sizeofKey64 :: SerialisedKey -> Word64
 sizeofKey64 = fromIntegral . sizeofKey
 
-toShortByteString :: SerialisedKey -> ShortByteString
-toShortByteString (SerialisedKey (ByteArray ba#)) = SBS ba#
-
 fromShortByteString :: ShortByteString -> SerialisedKey
-fromShortByteString (SBS ba#) = SerialisedKey (ByteArray ba#)
+fromShortByteString sbs@(SBS ba#) =
+    SerialisedKey (P.Vector 0 (SBS.length sbs) (ByteArray ba#))

--- a/src/utils/Database/LSMTree/Util/Orphans.hs
+++ b/src/utils/Database/LSMTree/Util/Orphans.hs
@@ -13,14 +13,13 @@ import           Control.DeepSeq (NFData (..))
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short.Internal as SBS
-import           Data.Primitive.ByteArray (ByteArray (..))
 import           Data.WideWord.Word256 (Word256 (..))
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           Database.LSMTree.Internal.Run.Index.Compact (Append (..),
                      CompactIndex (..), SearchResult (..))
 import           Database.LSMTree.Internal.Serialise (Serialise (..),
-                     SerialisedKey (..))
+                     SerialisedKey (..), fromShortByteString)
 import           GHC.Generics (Generic)
 import           System.Random (Uniform)
 
@@ -56,7 +55,7 @@ instance Serialise Word256 where
     where
       fromByteString :: LBS.ByteString -> SerialisedKey
       fromByteString =
-            (\(SBS.SBS ba) -> SerialisedKey (ByteArray ba))
+            fromShortByteString
           . SBS.toShort
           . LBS.toStrict
 
@@ -70,6 +69,6 @@ instance Serialise Word64 where
     where
       fromByteString :: LBS.ByteString -> SerialisedKey
       fromByteString =
-            (\(SBS.SBS ba) -> SerialisedKey (ByteArray ba))
+            fromShortByteString
           . SBS.toShort
           . LBS.toStrict

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,6 +8,7 @@ import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run.BloomFilter
 import qualified Test.Database.LSMTree.Internal.Run.Construction
 import qualified Test.Database.LSMTree.Internal.Run.Index.Compact
+import qualified Test.Database.LSMTree.Internal.Serialise
 import qualified Test.Database.LSMTree.Model.Monoidal
 import qualified Test.Database.LSMTree.Model.Normal
 import qualified Test.Database.LSMTree.ModelIO.Monoidal
@@ -21,6 +22,7 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Generators.tests
     , Test.Database.LSMTree.Internal.Run.Construction.tests
     , Test.Database.LSMTree.Internal.Run.Index.Compact.tests
+    , Test.Database.LSMTree.Internal.Serialise.tests
     , Test.Database.LSMTree.Internal.RawPage.tests
     , Test.Database.LSMTree.Model.Normal.tests
     , Test.Database.LSMTree.Model.Monoidal.tests

--- a/test/Test/Database/LSMTree/Internal/Serialise.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{- HLINT ignore "Use /=" -}
+
+module Test.Database.LSMTree.Internal.Serialise (tests) where
+
+import           Data.Bits
+import qualified Data.Vector.Primitive as P
+import           Data.Word
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Util (showPowersOf10)
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Internal.Serialise" [
+      testGroup "Eq and Ord laws" [
+          testProperty "Eq reflexivity" propEqReflexivity
+        , testProperty "Eq symmetry" propEqSymmetry
+        , localOption (QuickCheckMaxRatio 1000) $
+          testProperty "Eq transitivity" propEqTransitivity
+        , testProperty "Eq negation" propEqNegation
+        , testProperty "Ord comparability" propOrdComparability
+        , testProperty "Ord transitivity" propOrdTransitivity
+        , testProperty "Ord reflexivity" propOrdReflexivity
+        , localOption (QuickCheckMaxRatio 1000) $
+          testProperty "Ord antisymmetry" propOrdAntiSymmetry
+        ]
+    , testGroup "Distributions" [
+          testProperty "arbitrary SerialisedKey" distribution
+        , testProperty "shrink serialisedKey" $ conjoin . fmap distribution . shrink
+        ]
+    , testCase "example topBits16" $ do
+        let k = SerialisedKey (P.fromList [37, 42, 204, 130])
+            expected :: Word16
+            expected = 37 `shiftL` 8 + 42
+        topBits16 16 k @=? expected
+        topBits16 0  k @=? 0
+        topBits16 9  k @=? expected `shiftR` (16 - 9)
+    , testCase "example topBits16 on sliced byte array" $ do
+        let pvec = P.fromList [0, 37, 42, 204, 130]
+            k = SerialisedKey (P.slice 1 (P.length pvec - 1) pvec)
+            expected :: Word16
+            expected = 37 `shiftL` 8 + 42
+        topBits16 16 k @=? expected
+        topBits16 0  k @=? 0
+        topBits16 9  k @=? expected `shiftR` (16 - 9)
+    , testCase "example sliceBits32" $ do
+        let k = SerialisedKey (P.fromList [0, 0, 255, 255, 255, 255, 0])
+        0x0000FFFF @=? sliceBits32 0 k
+        0xFFFFFFFF @=? sliceBits32 16 k
+        0x7FFFFFFF @=? sliceBits32 15 k
+        0xFFFFFFFE @=? sliceBits32 17 k
+    , testCase "example sliceBits32 on sliced byte array" $ do
+        let pvec = P.fromList [0, 0, 0, 255, 255, 255, 255, 0]
+            k = SerialisedKey (P.slice 1 (P.length pvec - 1) pvec)
+        0x0000FFFF @=? sliceBits32 0 k
+        0xFFFFFFFF @=? sliceBits32 16 k
+        0x7FFFFFFF @=? sliceBits32 15 k
+        0xFFFFFFFE @=? sliceBits32 17 k
+    ]
+
+{-------------------------------------------------------------------------------
+  Eq and Ord laws
+-------------------------------------------------------------------------------}
+
+propEqReflexivity :: SerialisedKey -> Property
+propEqReflexivity k = k === k
+
+propEqSymmetry :: SerialisedKey -> SerialisedKey -> Property
+propEqSymmetry k1 k2 = (k1 == k2) === (k2 == k1)
+
+propEqTransitivity :: SmallSerialisedKey -> SmallSerialisedKey -> SmallSerialisedKey -> Property
+propEqTransitivity k1 k2 k3 = k1 == k2 && k2 == k3 ==> k1 === k3
+
+propEqNegation :: SerialisedKey -> SerialisedKey -> Property
+propEqNegation k1 k2 = (k1 /= k2) === not (k1 == k2)
+
+propOrdComparability :: SerialisedKey -> SerialisedKey -> Property
+propOrdComparability k1 k2 = k1 <= k2 .||. k2 <= k1
+
+propOrdTransitivity :: SerialisedKey -> SerialisedKey -> SerialisedKey -> Property
+propOrdTransitivity k1 k2 k3 = k1 <= k2 && k2 <= k3 ==> k1 <= k3
+
+propOrdReflexivity :: SerialisedKey -> Property
+propOrdReflexivity k = property $ k <= k
+
+propOrdAntiSymmetry :: SmallSerialisedKey -> SmallSerialisedKey -> Property
+propOrdAntiSymmetry k1 k2 = k1 <= k2 && k2 <= k1 ==> k1 === k2
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+distribution :: SerialisedKey -> Property
+distribution k =
+    tabulate "size of key in bytes" [showPowersOf10 $ sizeofKey k] $
+    property True
+
+instance Arbitrary SerialisedKey where
+  arbitrary = do
+    pvec <- P.fromList <$> arbitrary
+    n <- chooseInt (0, P.length pvec)
+    m <- chooseInt (0, P.length pvec - n)
+    pure $ SerialisedKey (P.slice m n pvec)
+  shrink (SerialisedKey pvec) =
+         [ SerialisedKey (P.fromList ws) | ws <- shrink (P.toList pvec) ]
+      ++ [ SerialisedKey (P.slice m n pvec)
+         | n <- shrink (P.length pvec)
+         , m <- shrink (P.length pvec - n)
+         ]
+
+newtype SmallSerialisedKey = SmallSerialisedKey SerialisedKey
+  deriving newtype (Show, Eq, Ord)
+
+instance Arbitrary SmallSerialisedKey where
+  arbitrary = do
+      n <- choose (0, 5)
+      SerialisedKey pvec <- arbitrary
+      pure $ SmallSerialisedKey (SerialisedKey (P.take n pvec))
+  shrink (SmallSerialisedKey k) = SmallSerialisedKey <$> shrink k


### PR DESCRIPTION
A nice result of this is that we can go from `SerialisedKey` to the `RawPage`-style keys and back without copying the raw bytes. However, copying is still necessary if the `RawPage`-style key comes from a reusable buffer