### PR TITLE
Serialise class and type for values

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Run/BloomFilter.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Run/BloomFilter.hs
@@ -17,8 +17,8 @@ import qualified Data.Map.Strict as Map
 import           Database.LSMTree.Extras
 import           Database.LSMTree.Generators
 import           Database.LSMTree.Internal.Run.BloomFilter as Bloom
-import           Database.LSMTree.Internal.Serialise (Serialise (serialise),
-                     SerialisedKey)
+import           Database.LSMTree.Internal.Serialise (SerialisedKey,
+                     serialiseKey)
 import           Database.LSMTree.Util.Orphans ()
 import           System.Random
 import           System.Random.Extras
@@ -60,7 +60,7 @@ elemEnv fpr nbloom nelemsPositive nelemsNegative = do
                   $ uniformWithoutReplacement    @UTxOKey stdgen  (nbloom + nelemsNegative)
         ys2       = sampleUniformWithReplacement @UTxOKey stdgen' nelemsPositive xs
     zs <- generate $ shuffle (ys1 ++ ys2)
-    pure (Bloom.Easy.easyList fpr (fmap serialise xs), fmap serialise zs)
+    pure (Bloom.Easy.easyList fpr (fmap serialiseKey xs), fmap serialiseKey zs)
 
 -- | Used for benchmarking 'Bloom.elem'.
 elems :: Bloom.Hashable a => Bloom a -> [a] -> ()
@@ -73,7 +73,7 @@ constructionEnv n = do
     stdgen' <- newStdGen
     let ks = uniformWithoutReplacement @UTxOKey stdgen n
         vs = uniformWithReplacement @UTxOKey stdgen' n
-    pure $ Map.fromList (zipWith (\k v -> (serialise k, serialise v)) ks vs)
+    pure $ Map.fromList (zipWith (\k v -> (serialiseKey k, serialiseKey v)) ks vs)
 
 -- | Used for benchmarking the construction of bloom filters from write buffers.
 constructBloom ::

--- a/bench/micro/Bench/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -13,8 +13,8 @@ import           Criterion.Main
 import           Data.Foldable (Foldable (..))
 import           Database.LSMTree.Generators
 import           Database.LSMTree.Internal.Run.Index.Compact
-import           Database.LSMTree.Internal.Serialise (Serialise (serialise),
-                     SerialisedKey)
+import           Database.LSMTree.Internal.Serialise (SerialisedKey,
+                     serialiseKey)
 import           System.Random
 import           System.Random.Extras
 import           Test.QuickCheck (generate)
@@ -45,7 +45,7 @@ searchEnv ::
 searchEnv rfprec npages nsearches = do
     ci <- constructCompactIndex 100 <$> constructionEnv rfprec npages
     stdgen  <- newStdGen
-    let ks = serialise <$> uniformWithReplacement @UTxOKey stdgen nsearches
+    let ks = serialiseKey <$> uniformWithReplacement @UTxOKey stdgen nsearches
     pure (ci, ks)
 
 -- | Used for benchmarking 'search'.

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -46,6 +46,8 @@ library
     Database.LSMTree.Internal.Run.Construction
     Database.LSMTree.Internal.Run.Index.Compact
     Database.LSMTree.Internal.Serialise
+    Database.LSMTree.Internal.Serialise.Class
+    Database.LSMTree.Internal.Serialise.RawBytes
     Database.LSMTree.Internal.WriteBuffer
     Database.LSMTree.Monoidal
     Database.LSMTree.Normal

--- a/src/Database/LSMTree/Internal/BlobRef.hs
+++ b/src/Database/LSMTree/Internal/BlobRef.hs
@@ -1,6 +1,15 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+
 module Database.LSMTree.Internal.BlobRef (
-    BlobRef (..),
-) where
+    BlobRef (..)
+  , BlobSpan (..)
+  ) where
+
+import           Control.DeepSeq (NFData)
+import           Data.Word (Word32, Word64)
+import           GHC.Generics (Generic)
 
 -- | A reference to an on-disk blob.
 --
@@ -11,3 +20,11 @@ module Database.LSMTree.Internal.BlobRef (
 -- values and is handled specially. In our context we will allow optionally a
 -- blob associated with each value in the table.
 data BlobRef blob = BlobRef
+
+-- | Location of a blob inside a blob file.
+data BlobSpan = BlobSpan {
+    blobSpanOffset :: !Word64
+  , blobSpanSize   :: !Word32
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass NFData

--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+-- | Public API for serialisation of keys, blobs and values
+module Database.LSMTree.Internal.Serialise.Class (
+    SerialiseKey (..)
+  , serialiseKeyIdentity
+  , serialiseKeyPreservesOrdering
+  , serialiseKeyMinimalSize
+  , SerialiseValue (..)
+  , serialiseValueIdentity
+  , serialiseValueConcatDistributes
+  , RawBytes (..)
+  ) where
+
+import           Data.Proxy (Proxy)
+import           Database.LSMTree.Internal.Serialise.RawBytes as RawBytes
+
+-- | Serialisation of keys.
+--
+-- Instances should satisfy the following:
+--
+-- [Identity] @'deserialiseKey' ('serialiseKey' x) == x@
+-- [Ordering-preserving] @x \`'compare'\` y == 'serialiseKey' x \`'compare'\` 'serialiseKey' y@
+--
+-- Raw bytes are lexicographically ordered, so in particular this means that
+-- values should be serialised into big-endian formats.
+--
+-- === CompactIndex constraints
+--
+-- When using the 'CompactIndex', additional constraints apply to the
+-- serialisation function, so in that case instances should also satisfy the
+-- following:
+--
+-- [Minimal size] @'sizeofRawBytes' >= 6@
+class SerialiseKey k where
+  serialiseKey :: k -> RawBytes
+  deserialiseKey :: RawBytes -> k
+
+-- | Test the __Identity__ law for the 'SerialiseKey' class
+serialiseKeyIdentity :: (Eq k, SerialiseKey k) => k -> Bool
+serialiseKeyIdentity x = deserialiseKey (serialiseKey x) == x
+
+-- | Test the __Ordering-preserving__ law for the 'SerialiseKey' class
+serialiseKeyPreservesOrdering :: (Ord k, SerialiseKey k) => k -> k -> Bool
+serialiseKeyPreservesOrdering x y = x `compare` y == serialiseKey x `compare` serialiseKey y
+
+-- | Test the __Minimal size__ law for the 'SerialiseKey' class.
+serialiseKeyMinimalSize :: SerialiseKey k => k -> Bool
+serialiseKeyMinimalSize x = sizeofRawBytes (serialiseKey x) >= 6
+
+-- | Serialisation of values and blobs.
+--
+-- Instances should satisfy the following:
+--
+-- [Identity] @'deserialiseValue' ('serialiseValue' x) == x@
+-- [Concat distributes] @'deserialiseValueN' xs == 'deserialiseValue' ('RawBytes.concat' xs)@
+class SerialiseValue v where
+  serialiseValue :: v -> RawBytes
+  deserialiseValue :: RawBytes -> v
+  -- | Deserialisation when bytes are split into multiple chunks.
+  deserialiseValueN :: [RawBytes] -> v
+
+-- | Test the __Identity__ law for the 'SerialiseValue' class
+serialiseValueIdentity :: (Eq v, SerialiseValue v) => v -> Bool
+serialiseValueIdentity x = deserialiseValue (serialiseValue x) == x
+
+-- | Test the __Concat distributes__ law for the 'SerialiseValue' class
+serialiseValueConcatDistributes :: forall v. (Eq v, SerialiseValue v) => Proxy v -> [RawBytes] -> Bool
+serialiseValueConcatDistributes _ xs = deserialiseValueN @v xs == deserialiseValue (RawBytes.concat xs)

--- a/src/Database/LSMTree/Internal/Serialise/RawBytes.hs
+++ b/src/Database/LSMTree/Internal/Serialise/RawBytes.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE MagicHash                  #-}
+{-# LANGUAGE UnboxedTuples              #-}
+{- HLINT ignore "Redundant lambda" -}
+
+#include <MachDeps.h>
+
+module Database.LSMTree.Internal.Serialise.RawBytes (
+    RawBytes (..)
+  , topBits16
+  , sliceBits32
+  , sizeofRawBytes
+  , Database.LSMTree.Internal.Serialise.RawBytes.concat
+    -- * @bytestring@ utils
+  , unsafeFromByteString
+  , fromShortByteString
+  , rawBytes
+  ) where
+
+import           Control.DeepSeq
+import           Control.Exception (assert)
+import           Data.Bits (Bits (shiftL, shiftR))
+import           Data.BloomFilter.Hash (hashList32)
+import           Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Builder.Internal as BB
+import           Data.ByteString.Internal as BS.Internal
+import           Data.ByteString.Short (ShortByteString (SBS))
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Short.Internal as SBS
+import           Data.Primitive.ByteArray (ByteArray (..), compareByteArrays)
+import qualified Data.Vector.Primitive as P
+import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
+import           Foreign.Ptr
+import           GHC.Exts
+import           GHC.ForeignPtr as GHC
+import           GHC.Word
+
+-- | Raw bytes with no alignment constraint (i.e. byte aligned), and no
+-- guarantee of pinned or unpinned memory (i.e. could be either).
+newtype RawBytes = RawBytes (P.Vector Word8)
+  deriving newtype (Show, NFData)
+
+toVector :: RawBytes -> P.Vector Word8
+toVector (RawBytes vec) = vec
+
+instance Eq RawBytes where
+  bs1 == bs2 = compareBytes bs1 bs2 == EQ
+
+-- | Lexicographical 'Ord' instance.
+instance Ord RawBytes where
+  compare = compareBytes
+
+-- | Based on @Ord 'ShortByteString'@.
+compareBytes :: RawBytes -> RawBytes -> Ordering
+compareBytes rb1@(RawBytes vec1) rb2@(RawBytes vec2) =
+    let !len1 = sizeofRawBytes rb1
+        !len2 = sizeofRawBytes rb2
+        !len  = min len1 len2
+     in case compareByteArrays ba1 off1 ba2 off2 len of
+          EQ | len1 < len2 -> LT
+             | len1 > len2 -> GT
+          o  -> o
+  where
+    P.Vector off1 _size1 ba1 = vec1
+    P.Vector off2 _size2 ba2 = vec2
+
+instance Hashable RawBytes where
+  hashIO32 :: RawBytes -> Word32 -> IO Word32
+  hashIO32 = hashRawBytes
+
+-- TODO: optimisation
+hashRawBytes :: RawBytes -> Word32 -> IO Word32
+hashRawBytes (RawBytes vec) = hashList32 (P.toList vec)
+
+-- | @'topBits16' n rb@ slices the first @n@ bits from the /top/ of the raw
+-- bytes @rb@. Returns the string of bits as a 'Word16'.
+--
+-- The /top/ corresponds to the most significant bit (big-endian).
+--
+-- PRECONDITION: @n >= 0 && n <= 16. We can slice out at most 16 bits,
+-- all bits beyond that are truncated.
+--
+-- PRECONDITION: The byte-size of the raw bytes should be at least 2 bytes.
+--
+-- TODO: optimisation ideas: use unsafe shift/byteswap primops, look at GHC
+-- core, find other opportunities for using primops.
+--
+topBits16 :: Int -> RawBytes -> Word16
+topBits16 n rb@(RawBytes (P.Vector (I# off#) _size (ByteArray k#))) =
+    assert (sizeofRawBytes rb >= 2) $ shiftR w16 (16 - n)
+  where
+    w16 = toWord16 (indexWord8ArrayAsWord16# k# off#)
+
+toWord16 :: Word16# -> Word16
+#if WORDS_BIGENDIAN
+toWord16 = W16#
+#else
+toWord16 x# = byteSwap16 (W16# x#)
+#endif
+
+-- | @'sliceBits32' off rb@ slices from the raw bytes @rb@ a string of @32@
+-- bits, starting at the @0@-based offset @off@. Returns the string of bits as a
+-- 'Word32'.
+--
+-- Offsets are counted in bits from the /top/: offset @0@ corresponds to the
+-- most significant bit (big-endian).
+--
+-- PRECONDITION: The raw bytes should be large enough that we can slice out 4
+-- bytes after the bit-offset @off@, since we can only slice out bits that are
+-- within the bounds of the byte array.
+--
+-- TODO: optimisation ideas: use unsafe shift/byteswap primops, look at GHC
+-- core, find other opportunities for using primops.
+--
+sliceBits32 :: Int -> RawBytes -> Word32
+sliceBits32 off@(I# off1#) rb@(RawBytes (P.Vector (I# off2#) _size (ByteArray ba#)))
+    | 0# <- r#
+    = assert (off + 32 <= 8 * sizeofRawBytes rb) $
+      toWord32 (indexWord8ArrayAsWord32# ba# q#)
+    | otherwise
+    = assert (off + 32 <= 8 * sizeofRawBytes rb) $
+        toWord32 (indexWord8ArrayAsWord32# ba# q#       ) `shiftL` r
+      + w8w32#   (indexWord8Array#         ba# (q# +# 4#)) `shiftR` (8 - r)
+  where
+    !(# q0#, r# #) = quotRemInt# off1# 8#
+    !q#            = q0# +# off2#
+    r              = I# r#
+    -- No need for byteswapping here
+    w8w32# x#     = W32# (wordToWord32# (word8ToWord# x#))
+
+toWord32 :: Word32# -> Word32
+#if WORDS_BIGENDIAN
+toWord32 = W32#
+#else
+toWord32 x# = byteSwap32 (W32# x#)
+#endif
+
+sizeofRawBytes :: RawBytes -> Int
+sizeofRawBytes (RawBytes pvec) = P.length pvec
+
+concat :: [RawBytes] -> RawBytes
+concat rbs = RawBytes (P.concat (fmap toVector rbs))
+
+{-------------------------------------------------------------------------------
+  @bytestring@ utils
+-------------------------------------------------------------------------------}
+
+-- | \( O(1) \) conversion from a strict bytestring to raw bytes.
+unsafeFromByteString :: BS.ByteString -> RawBytes
+unsafeFromByteString (BS.Internal.BS (GHC.ForeignPtr _ contents) n) =
+    case contents of
+      -- Strict bytestrings are allocated using 'mallocPlainForeignPtrBytes', so
+      -- we are expecting a 'PlainPtr' here.
+      PlainPtr mba# -> case unsafeFreezeByteArray# mba# realWorld# of
+                   (# _, ba# #) -> RawBytes (P.Vector 0 n (ByteArray ba#))
+      _            -> error "unsafeFromByteString: expected plain pointer"
+
+-- | \( O(1) \) conversion from a short bytestring to raw bytes.
+fromShortByteString :: ShortByteString -> RawBytes
+fromShortByteString sbs@(SBS ba#) =
+    RawBytes (P.Vector 0 (SBS.length sbs) (ByteArray ba#))
+
+{-# INLINE rawBytes #-}
+rawBytes :: RawBytes -> BB.Builder
+rawBytes (RawBytes (P.Vector off size (ByteArray ba#))) =
+    shortByteStringFromTo off (off + size) (SBS ba#)
+
+-- | Copy of 'SBS.shortByteString', but with bounds (unchecked)
+{-# INLINE shortByteStringFromTo #-}
+shortByteStringFromTo :: Int -> Int -> ShortByteString -> BB.Builder
+shortByteStringFromTo = \i j sbs -> BB.builder $ shortByteStringCopyStepFromTo i j sbs
+
+-- | Copy of 'SBS.shortByteStringCopyStep' but with bounds (unchecked)
+{-# INLINE shortByteStringCopyStepFromTo #-}
+shortByteStringCopyStepFromTo ::
+  Int -> Int -> ShortByteString -> BB.BuildStep a -> BB.BuildStep a
+shortByteStringCopyStepFromTo !ip0 !ipe0 !sbs k =
+    go ip0 ipe0
+  where
+    go !ip !ipe (BB.BufferRange op ope)
+      | inpRemaining <= outRemaining = do
+          SBS.copyToPtr sbs ip op inpRemaining
+          let !br' = BB.BufferRange (op `plusPtr` inpRemaining) ope
+          k br'
+      | otherwise = do
+          SBS.copyToPtr sbs ip op outRemaining
+          let !ip' = ip + outRemaining
+          return $ BB.bufferFull 1 ope (go ip' ipe)
+      where
+        outRemaining = ope `minusPtr` op
+        inpRemaining = ipe - ip

--- a/src/utils/Database/LSMTree/Util/Orphans.hs
+++ b/src/utils/Database/LSMTree/Util/Orphans.hs
@@ -18,8 +18,9 @@ import           Data.Word (Word64)
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           Database.LSMTree.Internal.Run.Index.Compact (Append (..),
                      CompactIndex (..), SearchResult (..))
-import           Database.LSMTree.Internal.Serialise (Serialise (..),
-                     SerialisedKey (..), fromShortByteString)
+import           Database.LSMTree.Internal.Serialise (SerialisedKey (..))
+import           Database.LSMTree.Internal.Serialise.Class
+import           Database.LSMTree.Internal.Serialise.RawBytes
 import           GHC.Generics (Generic)
 import           System.Random (Uniform)
 
@@ -44,31 +45,31 @@ deriving anyclass instance Uniform Word256
 instance Hashable Word256 where
   hashIO32 (Word256 a b c d) = hashIO32 (a, b, c, d)
 
-instance Serialise Word256 where
-  serialise (Word256{word256hi, word256m1, word256m0, word256lo}) =
-      fromByteString $ B.toLazyByteString $ mconcat [
+-- | Placeholder instance, not optimised
+instance SerialiseKey Word256 where
+  serialiseKey (Word256{word256hi, word256m1, word256m0, word256lo}) =
+      serialiseKey $ B.toLazyByteString $ mconcat [
           B.word64BE word256hi
         , B.word64BE word256m1
         , B.word64BE word256m0
         , B.word64BE word256lo
         ]
-    where
-      fromByteString :: LBS.ByteString -> SerialisedKey
-      fromByteString =
-            fromShortByteString
-          . SBS.toShort
-          . LBS.toStrict
+  deserialiseKey = error "deserialiseKey: Word256" -- TODO
 
 {-------------------------------------------------------------------------------
   Word64
 -------------------------------------------------------------------------------}
 
-instance Serialise Word64 where
-  serialise x =
-      fromByteString $ B.toLazyByteString $ B.word64BE x
-    where
-      fromByteString :: LBS.ByteString -> SerialisedKey
-      fromByteString =
-            fromShortByteString
-          . SBS.toShort
-          . LBS.toStrict
+-- | Placeholder instance, not optimised
+instance SerialiseKey Word64 where
+  serialiseKey x = serialiseKey $ B.toLazyByteString $ B.word64BE x
+  deserialiseKey = error "deserialiseKey: Word64" -- TODO
+
+{-------------------------------------------------------------------------------
+  ByteString
+-------------------------------------------------------------------------------}
+
+-- | Placeholder instance, not optimised
+instance SerialiseKey LBS.ByteString where
+  serialiseKey = fromShortByteString . SBS.toShort . LBS.toStrict
+  deserialiseKey = error "deserialiseKey: LazyByteString" -- TODO

--- a/test/Test/Database/LSMTree/Internal/Serialise.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise.hs
@@ -7,9 +7,13 @@
 module Test.Database.LSMTree.Internal.Serialise (tests) where
 
 import           Data.Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Short as SBS
 import qualified Data.Vector.Primitive as P
 import           Data.Word
 import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.Serialise.RawBytes
 import           Database.LSMTree.Util (showPowersOf10)
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -17,7 +21,7 @@ import           Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Internal.Serialise" [
-      testGroup "Eq and Ord laws" [
+      testGroup "SerialisedKey Eq and Ord laws" [
           testProperty "Eq reflexivity" propEqReflexivity
         , testProperty "Eq symmetry" propEqSymmetry
         , localOption (QuickCheckMaxRatio 1000) $
@@ -33,34 +37,40 @@ tests = testGroup "Test.Database.LSMTree.Internal.Serialise" [
           testProperty "arbitrary SerialisedKey" distribution
         , testProperty "shrink serialisedKey" $ conjoin . fmap distribution . shrink
         ]
-    , testCase "example topBits16" $ do
-        let k = SerialisedKey (P.fromList [37, 42, 204, 130])
+    , testCase "example keyTopBits16" $ do
+        let k = SerialisedKey' (P.fromList [37, 42, 204, 130])
             expected :: Word16
             expected = 37 `shiftL` 8 + 42
-        topBits16 16 k @=? expected
-        topBits16 0  k @=? 0
-        topBits16 9  k @=? expected `shiftR` (16 - 9)
-    , testCase "example topBits16 on sliced byte array" $ do
+        expected                   @=? keyTopBits16 16 k
+        0                          @=? keyTopBits16 0  k
+        expected `shiftR` (16 - 9) @=? keyTopBits16 9  k
+    , testCase "example keyTopBits16 on sliced byte array" $ do
         let pvec = P.fromList [0, 37, 42, 204, 130]
-            k = SerialisedKey (P.slice 1 (P.length pvec - 1) pvec)
+            k = SerialisedKey' (P.slice 1 (P.length pvec - 1) pvec)
             expected :: Word16
             expected = 37 `shiftL` 8 + 42
-        topBits16 16 k @=? expected
-        topBits16 0  k @=? 0
-        topBits16 9  k @=? expected `shiftR` (16 - 9)
-    , testCase "example sliceBits32" $ do
-        let k = SerialisedKey (P.fromList [0, 0, 255, 255, 255, 255, 0])
-        0x0000FFFF @=? sliceBits32 0 k
-        0xFFFFFFFF @=? sliceBits32 16 k
-        0x7FFFFFFF @=? sliceBits32 15 k
-        0xFFFFFFFE @=? sliceBits32 17 k
-    , testCase "example sliceBits32 on sliced byte array" $ do
+        expected                   @=? keyTopBits16 16 k
+        0                          @=? keyTopBits16 0  k
+        expected `shiftR` (16 - 9) @=? keyTopBits16 9  k
+    , testCase "example keySliceBits32" $ do
+        let k = SerialisedKey' (P.fromList [0, 0, 255, 255, 255, 255, 0])
+        0x0000FFFF @=? keySliceBits32 0 k
+        0xFFFFFFFF @=? keySliceBits32 16 k
+        0x7FFFFFFF @=? keySliceBits32 15 k
+        0xFFFFFFFE @=? keySliceBits32 17 k
+    , testCase "example keySliceBits32 on sliced byte array" $ do
         let pvec = P.fromList [0, 0, 0, 255, 255, 255, 255, 0]
-            k = SerialisedKey (P.slice 1 (P.length pvec - 1) pvec)
-        0x0000FFFF @=? sliceBits32 0 k
-        0xFFFFFFFF @=? sliceBits32 16 k
-        0x7FFFFFFF @=? sliceBits32 15 k
-        0xFFFFFFFE @=? sliceBits32 17 k
+            k = SerialisedKey' (P.slice 1 (P.length pvec - 1) pvec)
+        0x0000FFFF @=? keySliceBits32 0 k
+        0xFFFFFFFF @=? keySliceBits32 16 k
+        0x7FFFFFFF @=? keySliceBits32 15 k
+        0xFFFFFFFE @=? keySliceBits32 17 k
+    , testCase "example unsafeFromByteString and fromShortByteString" $ do
+        let bb = mconcat [BB.word64LE x | x <- [0..100]]
+            bs = BS.toStrict . BB.toLazyByteString $ bb
+            k1 = unsafeFromByteString bs
+            k2 = fromShortByteString (SBS.toShort bs)
+        k1 @=? k2
     ]
 
 {-------------------------------------------------------------------------------
@@ -105,10 +115,10 @@ instance Arbitrary SerialisedKey where
     pvec <- P.fromList <$> arbitrary
     n <- chooseInt (0, P.length pvec)
     m <- chooseInt (0, P.length pvec - n)
-    pure $ SerialisedKey (P.slice m n pvec)
-  shrink (SerialisedKey pvec) =
-         [ SerialisedKey (P.fromList ws) | ws <- shrink (P.toList pvec) ]
-      ++ [ SerialisedKey (P.slice m n pvec)
+    pure $ SerialisedKey' (P.slice m n pvec)
+  shrink (SerialisedKey' pvec) =
+         [ SerialisedKey' (P.fromList ws) | ws <- shrink (P.toList pvec) ]
+      ++ [ SerialisedKey' (P.slice m n pvec)
          | n <- shrink (P.length pvec)
          , m <- shrink (P.length pvec - n)
          ]
@@ -119,6 +129,6 @@ newtype SmallSerialisedKey = SmallSerialisedKey SerialisedKey
 instance Arbitrary SmallSerialisedKey where
   arbitrary = do
       n <- choose (0, 5)
-      SerialisedKey pvec <- arbitrary
-      pure $ SmallSerialisedKey (SerialisedKey (P.take n pvec))
+      SerialisedKey (RawBytes pvec) <- arbitrary
+      pure $ SmallSerialisedKey (SerialisedKey' (P.take n pvec))
   shrink (SmallSerialisedKey k) = SmallSerialisedKey <$> shrink k

--- a/test/Test/Util/Orphans.hs
+++ b/test/Test/Util/Orphans.hs
@@ -22,7 +22,7 @@ import qualified Control.Concurrent.STM as Real
 import           Control.Monad ((<=<))
 import           Control.Monad.IOSim (IOSim)
 import           Data.Kind (Type)
-import           Database.LSMTree.Internal.Serialise (Serialise)
+import           Database.LSMTree.Internal.Serialise (SerialiseKey)
 import qualified Database.LSMTree.Monoidal as Monoidal
 import           Database.LSMTree.Normal
 import           Test.QuickCheck (Arbitrary (..), frequency, oneof)
@@ -111,4 +111,4 @@ instance InterpretOp SumProd.Op (Op.WrapRealized (IOSim s)) where
   QuickCheck
 -------------------------------------------------------------------------------}
 
-deriving newtype instance Serialise a => Serialise (Small a)
+deriving newtype instance SerialiseKey a => SerialiseKey (Small a)


### PR DESCRIPTION
Update serialisation primitives for values and blobs. Also did some refactoring of the code to put it into separate modules:

* `D.L.I.Serialise`: intended for internal use, with newtype wrappers for extra safety
* `D.L.I.Serialise.Class`: intended for the public API. I didn't swap out the `SomeSerialisationConstraint` class yet, because that would further inflate the diff, so I'll do it in a follow-up PR.
* `D.L.I.Serialise.RawBytes`: intended mainly for internal use (like bit-slicing), but since `RawBytes` is the target/source type for serialisation/deserialisation, the type is also re-exported from `Class`