### PR TITLE
Tweaks to the file format spec for the compact index

### DIFF
--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -185,9 +185,9 @@ whole key per page: we can typically store just 4 bytes (32bits) per page. This
 is a factor of 8 saving for 32 byte keys.
 
 The representation consists of
-1. the number of range finder bits (0..16)
-2. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
-3. a primary array of 32bit words, one entry per page in the index
+1. a primary array of 32bit words, one entry per page in the index
+2. the number of range finder bits (0..16)
+3. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
 4. a clash indicator bit vector, one bit per page in the index
 5. a clash map, mapping each page with a clash indicator to the full minimum
    key for the page
@@ -195,14 +195,9 @@ The representation consists of
 The file format consists of each part, sequentially within the file. This
 format can in-part be written out incrementally as the index is constructed.
 The primary array is the largest component, and this is the part that can be
-written out to disk incrementally. Its size is bounded but not known precisely
-prior to the completion of the index. The range finder array cannot be written
-until index completion, but its size is known in advance and so space in the
-file can be reserved. The clash indicator bit vector has the same number of
-elements as the primary array, but is of course 32 times smaller, so it is
-reasonable to keep this in memory while the index is constructed and flush it
-upon completion. Similarly, the clash map is small and it can be written upon
-index completion.
+written out to disk incrementally. All the remaining parts can only be written
+upon the completion of the index. These parts must be kept in memory while the
+index is constructed and can be flushed upon completion.
 
 ### Ordinary index
 

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -189,7 +189,8 @@ The representation consists of
 2. the number of range finder bits (0..16)
 3. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
 4. a clash indicator bit vector, one bit per page in the index
-5. a clash map, mapping each page with a clash indicator to the full minimum
+5. a larger-than-page indicator bit vector, one bit per page in the index
+6. a clash map, mapping each page with a clash indicator to the full minimum
    key for the page
 
 The file format consists of each part, sequentially within the file. This

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -191,7 +191,7 @@ The representation consists of
 4. a larger-than-page indicator bit vector, one bit per page in the index
 5. a clash map, mapping each page with a clash indicator to the full minimum
    key for the page
-6. the number of range finder bits (0..16) (as a 8bit value)
+6. the number of range finder bits (0..16) (as a 64bit value)
 7. the number of pages in the primary array (as a 64bit value)
 8. the number of keys in the corresponding key/ops file (as a 64bit value)
 
@@ -207,6 +207,21 @@ means they are at a known offset relative to the end of the file, and can be
 read first. This helps with pre-allocating the memory needed for the
 in-memory representation of the other main components, and knowing how much
 data to read from disk for each component.
+
+Size granularity, alignment and any trailing padding of the components:
+1. 32bit size granularity, 32bit alignment
+2. 32bit size granularity, 32bit alignment, trailing padding to 64bit alignment
+3. 64bit size granularity, 64bit alignment
+4. 64bit size granularity, 64bit alignment
+5. 8bit size granularity, 8bit alignment, trailing padding to 64bit alignment
+6. 64bit size granularity, 64bit alignment
+7. 64bit size granularity, 64bit alignment
+8. 64bit size granularity, 64bit alignment
+
+The alignment of the components is arranged such that it would be possible (if
+desired) to mmap the whole file and access almost all of the components with
+natural alignment. The clash map however is not a simple flat array, so it is
+is expected to be decoded, rather than to be accessed in-place.
 
 ### Ordinary index
 

--- a/doc/format-run.md
+++ b/doc/format-run.md
@@ -186,12 +186,14 @@ is a factor of 8 saving for 32 byte keys.
 
 The representation consists of
 1. a primary array of 32bit words, one entry per page in the index
-2. the number of range finder bits (0..16)
-3. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
-4. a clash indicator bit vector, one bit per page in the index
-5. a larger-than-page indicator bit vector, one bit per page in the index
-6. a clash map, mapping each page with a clash indicator to the full minimum
+2. a range finder array, of 2^n+1 entries of 32bit each (n = range finder bits)
+3. a clash indicator bit vector, one bit per page in the index
+4. a larger-than-page indicator bit vector, one bit per page in the index
+5. a clash map, mapping each page with a clash indicator to the full minimum
    key for the page
+6. the number of range finder bits (0..16) (as a 8bit value)
+7. the number of pages in the primary array (as a 64bit value)
+8. the number of keys in the corresponding key/ops file (as a 64bit value)
 
 The file format consists of each part, sequentially within the file. This
 format can in-part be written out incrementally as the index is constructed.
@@ -199,6 +201,12 @@ The primary array is the largest component, and this is the part that can be
 written out to disk incrementally. All the remaining parts can only be written
 upon the completion of the index. These parts must be kept in memory while the
 index is constructed and can be flushed upon completion.
+
+The rationale for the various numbers being at the end of the file is that it
+means they are at a known offset relative to the end of the file, and can be
+read first. This helps with pre-allocating the memory needed for the
+in-memory representation of the other main components, and knowing how much
+data to read from disk for each component.
 
 ### Ordinary index
 


### PR DESCRIPTION
* Reorder components to allow incremental writes, with CRC calculations
* Add the LTP bit array
* Put sizes at the end to simplify reading