### PR TITLE
Minor optimisations for `prepLookups`

### DIFF
--- a/src/utils/Database/LSMTree/Generators.hs
+++ b/src/utils/Database/LSMTree/Generators.hs
@@ -70,7 +70,7 @@ import           Test.QuickCheck.Gen (genDouble)
   WithSerialised
 -------------------------------------------------------------------------------}
 
--- | Cach serialised keys
+-- | Cache serialised keys
 --
 -- Also useful for failing tests that have keys as inputs, because the printed
 -- 'WithSerialised' values will show both keys and their serialised form.

--- a/src/utils/Database/LSMTree/Util/Orphans.hs
+++ b/src/utils/Database/LSMTree/Util/Orphans.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE NamedFieldPuns     #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -17,24 +18,29 @@ import           Data.WideWord.Word256 (Word256 (..))
 import           Data.Word (Word64)
 import           Database.LSMTree.Internal.Run.BloomFilter (Hashable (..))
 import           Database.LSMTree.Internal.Run.Index.Compact (Append (..),
-                     CompactIndex (..), SearchResult (..))
+                     CompactIndex (..), PageNo (..), PageSpan (..),
+                     SearchResult (..))
 import           Database.LSMTree.Internal.Serialise (SerialisedKey (..))
 import           Database.LSMTree.Internal.Serialise.Class
 import           Database.LSMTree.Internal.Serialise.RawBytes
 import           GHC.Generics (Generic)
 import           System.Random (Uniform)
 
-deriving instance Generic SerialisedKey
-deriving instance NFData SerialisedKey
+deriving newtype instance NFData SerialisedKey
 
-deriving instance Generic SearchResult
-deriving instance NFData SearchResult
+deriving stock instance Generic SearchResult
+deriving anyclass instance NFData SearchResult
 
-deriving instance Generic Append
-deriving instance NFData Append
+deriving newtype instance NFData PageNo
 
-deriving instance Generic CompactIndex
-deriving instance NFData CompactIndex
+deriving stock instance Generic PageSpan
+deriving anyclass instance NFData PageSpan
+
+deriving stock instance Generic Append
+deriving anyclass instance NFData Append
+
+deriving stock instance Generic CompactIndex
+deriving anyclass instance NFData CompactIndex
 
 {-------------------------------------------------------------------------------
   Word256

--- a/test/Test/Database/LSMTree/Internal/Run/Index/Compact.hs
+++ b/test/Test/Database/LSMTree/Internal/Run/Index/Compact.hs
@@ -106,15 +106,15 @@ prop_searchMinMaxKeysAfterConstruction csize ps = eqMapProp real model
     modelSearch m = \case
         OnePageOneKey k       -> do
           c <- incrCounter
-          pure $ Map.insert k (SinglePage c) m
+          pure $ Map.insert k (SinglePage (PageNo c)) m
         OnePageManyKeys k1 k2 -> do
           c <- incrCounter
-          pure $ Map.insert k1 (SinglePage c) $ Map.insert k2 (SinglePage c) m
+          pure $ Map.insert k1 (SinglePage (PageNo c)) $ Map.insert k2 (SinglePage (PageNo c)) m
         MultiPageOneKey k n -> do
           let incr = 1 + fromIntegral n
           c <- plusCounter incr
-          pure $ if incr == 1 then Map.insert k (SinglePage c) m
-                              else Map.insert k (MultiPage c (c + fromIntegral n)) m
+          pure $ if incr == 1 then Map.insert k (SinglePage (PageNo c)) m
+                              else Map.insert k (MultiPage (PageNo c) (PageNo $ c + fromIntegral n)) m
 
     real = foldMap' realSearch (getPages ps)
 


### PR DESCRIPTION
Changed `prepLookups` to return a flat list instead of a list of lists. Also, added some newtypes like `PageSpan` and `PageNo`, and removed an indirection from the compact index `search` code.

I compared benchmarks before and after the change, using a fixed seed for the `prepLookups` micro-benchmark. I only benchmarked the default configuration with only positive lookups, because it exercises the most code (i.e., one bloom query and index search for each key-run combination).I also look at the allocations vs. iterations regression.

On 9020d6fe2870e7b137387d821fbc22aa7f71db1e:
```
benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/Bloomfilter query
time                 23.48 ms   (23.23 ms .. 23.67 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 24.24 ms   (24.02 ms .. 24.49 ms)
std dev              513.5 μs   (440.8 μs .. 614.9 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.284e8    (1.284e8 .. 1.284e8)
  y                  3557.754   (2426.069 .. 4857.572)

benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/Compact index search
time                 1.436 ms   (1.428 ms .. 1.446 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.489 ms   (1.478 ms .. 1.501 ms)
std dev              40.33 μs   (33.06 μs .. 47.93 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              335984.249 (335975.127 .. 335994.738)
  y                  3084.319   (2453.477 .. 3716.594)
variance introduced by outliers: 15% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/In-memory lookup
time                 26.08 ms   (25.90 ms .. 26.41 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 25.34 ms   (24.96 ms .. 25.64 ms)
std dev              756.0 μs   (550.2 μs .. 1.042 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.332e8    (1.332e8 .. 1.332e8)
  y                  2140.211   (557.682 .. 3815.530)
```

On d6cffc092054630b761618bdae17049d5698805b:
```
benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/Bloomfilter query
time                 22.43 ms   (22.20 ms .. 22.69 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 22.67 ms   (22.58 ms .. 22.74 ms)
std dev              182.9 μs   (126.1 μs .. 253.0 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.284e8    (1.284e8 .. 1.284e8)
  y                  3510.737   (2411.617 .. 4691.646)

benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/Compact index search
time                 1.440 ms   (1.434 ms .. 1.445 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.485 ms   (1.474 ms .. 1.501 ms)
std dev              43.97 μs   (34.80 μs .. 54.69 μs)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              335984.612 (335975.994 .. 335993.636)
  y                  3062.105   (2468.657 .. 3687.059)
variance introduced by outliers: 17% (moderately inflated)

benchmarking Bench.Database.LSMTree.Internal.Integration/prepLookups for a single run/default, ? actual pages/In-memory lookup
time                 25.23 ms   (24.88 ms .. 25.60 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 24.11 ms   (23.65 ms .. 24.49 ms)
std dev              922.6 μs   (695.7 μs .. 1.221 ms)
allocated:           1.000 R²   (1.000 R² .. 1.000 R²)
  iters              1.315e8    (1.315e8 .. 1.315e8)
  y                  2580.351   (1096.852 .. 4400.048)
```

Note that comparison will be rather imprecise, because the reported time allocation numbers are rounded. Time goes down a little it for "in-memory lookup", and allocations go down by roughly `0.017 * 10 ^ 8` . Though this may not look like much in the grand scheme of things, it shaves off roughly `1/3` of the allocations for `prepLookups` that can not be attributed to bloom filter queries or compact index searches.

These results also re-emphasise that bloom filter queries are quite costly
