### PR TITLE
Test for in-memory run construction and lookups

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -132,6 +132,7 @@ library lsm-tree-utils
     , QuickCheck
     , quickcheck-instances
     , random
+    , vector
     , wide-word
 
 test-suite lsm-tree-test
@@ -152,6 +153,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Internal.BloomFilter
     Test.Database.LSMTree.Internal.CRC32C
     Test.Database.LSMTree.Internal.Entry
+    Test.Database.LSMTree.Internal.Lookup
     Test.Database.LSMTree.Internal.RawPage
     Test.Database.LSMTree.Internal.Run
     Test.Database.LSMTree.Internal.Run.BloomFilter
@@ -167,6 +169,7 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Normal.StateMachine
     Test.Database.LSMTree.Normal.StateMachine.Op
     Test.Util.Orphans
+    Test.Util.QuickCheck
     Test.Util.RawPage
     Test.Util.TypeFamilyWrappers
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import qualified Test.Database.LSMTree.Common
 import qualified Test.Database.LSMTree.Generators
 import qualified Test.Database.LSMTree.Internal.BloomFilter
 import qualified Test.Database.LSMTree.Internal.Entry
+import qualified Test.Database.LSMTree.Internal.Lookup
 import qualified Test.Database.LSMTree.Internal.RawPage
 import qualified Test.Database.LSMTree.Internal.Run
 import qualified Test.Database.LSMTree.Internal.Run.BloomFilter
@@ -25,6 +26,7 @@ main = defaultMain $ testGroup "lsm-tree"
     , Test.Database.LSMTree.Generators.tests
     , Test.Database.LSMTree.Internal.BloomFilter.tests
     , Test.Database.LSMTree.Internal.Entry.tests
+    , Test.Database.LSMTree.Internal.Lookup.tests
     , Test.Database.LSMTree.Internal.RawPage.tests
     , Test.Database.LSMTree.Internal.Run.tests
     , Test.Database.LSMTree.Internal.Run.BloomFilter.tests

--- a/test/Test/Database/LSMTree/Generators.hs
+++ b/test/Test/Database/LSMTree/Generators.hs
@@ -1,43 +1,53 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.Database.LSMTree.Generators (tests) where
+module Test.Database.LSMTree.Generators (
+    tests
+  , prop_arbitraryAndShrinkPreserveInvariant
+  , prop_forAllArbitraryAndShrinkPreserveInvariant
+  , deepseqInvariant
+  ) where
 
+import           Control.DeepSeq (NFData, deepseq)
 import           Data.ByteString (ByteString)
 import           Data.Word (Word64)
-import           Database.LSMTree.Generators (ChunkSize, LogicalPageSummaries,
-                     RFPrecision, chunkSizeInvariant, pagesInvariant,
-                     rfprecInvariant, writeBufferInvariant)
+import           Database.LSMTree.Generators (chunkSizeInvariant,
+                     pagesInvariant, rfprecInvariant, writeBufferInvariant)
+import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes)
 import           Test.Database.LSMTree.Internal.Run.Index.Compact ()
-import           Test.QuickCheck (Arbitrary (..), Testable (..))
+import           Test.QuickCheck (Arbitrary (..), Gen, Testable (..),
+                     forAllShrink)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests = testGroup "Test.Database.LSMTree.Generators" [
-      testGroup "WriteBuffer" [
-          testProperty "Arbitrary satisfies invariant" $ property $
-            writeBufferInvariant @ByteString @ByteString @ByteString
-        , testProperty "Shrinking satisfies invariant" $ property $
-            all (writeBufferInvariant @ByteString @ByteString @ByteString)
-              . shrink
-      ]
-    , testGroup "Range-finder bit-precision" [
-          testProperty "Arbitrary satisfies invariant" $
-            property . rfprecInvariant
-        , testProperty "Shrinking satisfies invariant" $
-            property . all rfprecInvariant . shrink @RFPrecision
-      ]
-    , testGroup "LogicalPageSummaries" [
-          testProperty "Arbitrary satisfies invariant" $
-            property . pagesInvariant @Word64
-        , testProperty "Shrinking satisfies invariant" $
-            property . all pagesInvariant . shrink @(LogicalPageSummaries Word64)
-        ]
-    , testGroup "Chunk size" [
-        testProperty "Arbitrary satisfies invariant" $
-            property . chunkSizeInvariant
-        , testProperty "Shrinking satisfies invariant" $
-            property . all chunkSizeInvariant . shrink @ChunkSize
-        ]
+      testGroup "WriteBuffer" $
+        prop_arbitraryAndShrinkPreserveInvariant (writeBufferInvariant @ByteString @ByteString @ByteString)
+    , testGroup "Range-finder bit-precision" $
+        prop_arbitraryAndShrinkPreserveInvariant rfprecInvariant
+    , testGroup "LogicalPageSummaries" $
+        prop_arbitraryAndShrinkPreserveInvariant (pagesInvariant @Word64)
+    , testGroup "Chunk size" $
+        prop_arbitraryAndShrinkPreserveInvariant chunkSizeInvariant
+    , testGroup "Raw bytes" $
+        prop_arbitraryAndShrinkPreserveInvariant (deepseqInvariant @RawBytes)
     ]
+
+prop_arbitraryAndShrinkPreserveInvariant ::
+    forall a. (Arbitrary a, Show a) => (a -> Bool) -> [TestTree]
+prop_arbitraryAndShrinkPreserveInvariant =
+    prop_forAllArbitraryAndShrinkPreserveInvariant arbitrary shrink
+
+prop_forAllArbitraryAndShrinkPreserveInvariant ::
+    forall a. Show a => Gen a -> (a -> [a]) -> (a -> Bool) -> [TestTree]
+prop_forAllArbitraryAndShrinkPreserveInvariant gen shr inv =
+    [ testProperty "Arbitrary satisfies invariant" $
+            property $ forAllShrink gen shr inv
+    , testProperty "Shrinking satisfies invariant" $
+            property $ forAllShrink gen shr (all inv . shr)
+    ]
+
+-- | Trivial invariant, but checks that the value is finite
+deepseqInvariant :: NFData a => a -> Bool
+deepseqInvariant x = x `deepseq` True

--- a/test/Test/Database/LSMTree/Internal/Lookup.hs
+++ b/test/Test/Database/LSMTree/Internal/Lookup.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Database.LSMTree.Internal.Lookup (tests) where
+
+import           Control.DeepSeq
+import           Control.Monad.ST.Strict
+import           Data.Bifunctor
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Short as SBS
+import           Data.Coerce (coerce)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe
+import           Data.Primitive.ByteArray (ByteArray (ByteArray),
+                     sizeofByteArray)
+import qualified Data.Set as Set
+import qualified Data.Vector.Primitive as P
+import           Data.Word
+import           Database.LSMTree.Generators
+import           Database.LSMTree.Internal.BlobRef (BlobSpan)
+import           Database.LSMTree.Internal.Entry
+import           Database.LSMTree.Internal.Lookup
+import           Database.LSMTree.Internal.RawPage
+import           Database.LSMTree.Internal.Run.BloomFilter as Bloom
+import           Database.LSMTree.Internal.Run.Construction as Run
+import           Database.LSMTree.Internal.Run.Index.Compact as Index
+import           Database.LSMTree.Internal.Serialise
+import           Database.LSMTree.Internal.Serialise.Class
+import           Database.LSMTree.Internal.Serialise.RawBytes as RB
+import           Database.LSMTree.Util
+import           GHC.Generics
+import           Test.Database.LSMTree.Generators (deepseqInvariant,
+                     prop_arbitraryAndShrinkPreserveInvariant,
+                     prop_forAllArbitraryAndShrinkPreserveInvariant)
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Util.Orphans ()
+import           Test.Util.QuickCheck as Util.QC
+
+tests :: TestTree
+tests = testGroup "Test.Database.LSMTree.Internal.Integration" [
+      testGroup "With multi-page values" [
+          testGroup "InMemLookupData" $
+            prop_arbitraryAndShrinkPreserveInvariant (deepseqInvariant @(InMemLookupData SerialisedKey SerialisedValue))
+        , localOption (QuickCheckMaxSize 1000) $
+          testProperty "prop_inMemRunLookupAndConstruction" prop_inMemRunLookupAndConstruction
+
+        ]
+    , testGroup "Without multi-page values" [
+          testGroup "InMemLookupData" $
+            prop_forAllArbitraryAndShrinkPreserveInvariant
+              genNoMultiPage
+              shrinkNoMultiPage
+              (deepseqInvariant @(InMemLookupData SerialisedKey SerialisedValue))
+        , localOption (QuickCheckMaxSize 1000) $
+          testProperty "prop_inMemRunLookupAndConstruction" $
+            forAllShrink genNoMultiPage shrinkNoMultiPage prop_inMemRunLookupAndConstruction
+        ]
+    ]
+  where
+    genNoMultiPage = liftArbitrary arbitrary
+    shrinkNoMultiPage = liftShrink shrink
+
+-- | Construct a run incrementally, then test a number of positive and negative lookups.
+prop_inMemRunLookupAndConstruction :: InMemLookupData SerialisedKey SerialisedValue -> Property
+prop_inMemRunLookupAndConstruction dat =
+    Map.size runData > 0 ==>
+        tabulateKeySizes
+      $ tabulateValueSizes
+      $ tabulateNumKeyEntryPairs
+      $ tabulateNumPages
+      $ tabulateNumLookups
+      $ conjoin (fmap checkMaybeInRun keysMaybeInRun) .&&. conjoin (fmap checkNotInRun keysNotInRun)
+  where
+    InMemLookupData{runData, lookups} = dat
+
+    tabulateKeySizes = tabulate "Size of key in run" [showPowersOf10 $ sizeofKey k | k <- Map.keys runData ]
+    tabulateValueSizes = tabulate "Size of value in run" [showPowersOf10 $ onValue 0 sizeofValue e | e <- Map.elems runData]
+    tabulateNumKeyEntryPairs = tabulate "Number of key-entry pairs" [showPowersOf10 (Map.size runData) ]
+    tabulateNumPages = tabulate "Number of pages" [showPowersOf10 (Map.size ps) | let (ps, _, _) = run]
+    tabulateNumLookups = tabulate "Number of lookups" [showPowersOf10 (length lookups)]
+
+    run = mkTestRun runData
+    -- prepLookups says that a key /could be/ in the given page
+    keysMaybeInRun = prepLookups [run] lookups
+    -- prepLookups says that a key /is definitely not/ in the given page
+    keysNotInRun = Set.toList (Set.fromList lookups Set.\\ Set.fromList (fmap fst keysMaybeInRun))
+
+    -- Check that a key /is definitely not/ in the given page.
+    checkNotInRun :: SerialisedKey -> Property
+    checkNotInRun k =
+          tabulate1Pre (classifyBin (isJust truth) False)
+        $ truth === test
+      where truth = Map.lookup k runData
+            test  = Nothing
+
+    -- | Check that a key /could be/ in the given page
+    checkMaybeInRun :: (SerialisedKey, (Map Int RawPage, PageSpan)) -> Property
+    checkMaybeInRun (k, (ps, PageSpan (PageNo i) (PageNo j)))
+      | i <= j    = tabulate "PageSpan size" [showPowersOf10 $ j - i + 1]
+                  $ tabulate1Pre (classifyBin (isJust truth) True)
+                  $ truth === test
+      | otherwise = error "impossible: end of a page span can not come before its start"
+      where
+        truth = Map.lookup k runData
+        test  = case rawPageLookup (ps Map.! i) (coerce k) of
+          LookupEntryNotPresent       -> Nothing
+          LookupEntry entry           -> Just entry
+          LookupEntryOverflow entry n -> Just (first (concatOverflow n) entry)
+
+        -- read remaining bytes for a multi-page value, and append it to the
+        -- prefix we already have
+        concatOverflow :: Word32 -> SerialisedValue -> SerialisedValue
+        concatOverflow = coerce $ \(n :: Word32) (v :: RawBytes) ->
+            v <> RB.takeRawBytes (fromIntegral n) (mconcat $ fmap rawPageRawBytes overflowPages)
+          where
+            start = i + 1
+            size  = j - i
+            overflowPages = Map.elems $ Map.take size (Map.drop start ps)
+
+    tabulate1Pre :: BinaryClassification -> Property -> Property
+    tabulate1Pre  x = tabulate "Lookup classification: pre intra-page lookup"  [show x]
+
+type TestRun = (Map Int RawPage, Bloom SerialisedKey, CompactIndex)
+
+mkTestRun :: Map SerialisedKey (Entry SerialisedValue BlobSpan) -> TestRun
+mkTestRun dat = (rawPages, b, cix)
+  where
+    nentries = NumEntries (Map.size dat)
+    -- suggested range-finder precision is going to be @0@ anyway unless the
+    -- input data is very big
+    npages   = 0
+
+    -- one-shot run construction
+    (paccs, b, cix) = runST $ do
+      racc <- Run.new nentries npages
+      let kops = Map.toList dat
+      mps <- traverse (uncurry (addFullKOp racc)) kops
+      (mp, _ , _, bb, cixx) <- unsafeFinalise racc
+      pure (mapMaybe (fmap fst) (mps ++ [mp]), bb, cixx)
+
+    -- create a mapping of page numbers to raw pages, which we can use to do
+    -- intra-page lookups on after first probing the bloom filter and index
+    runBuilder = foldMap pageBuilder paccs
+    runBytesS  = SBS.toShort $ BS.toStrict $ BB.toLazyByteString runBuilder
+    runBytes   = case runBytesS of SBS.SBS ba -> ByteArray ba
+    rawPages   = Map.fromList [ (i, makeRawPage runBytes (i * 4096))
+                              | i <- [0 .. sizeofByteArray runBytes `div` 4096] ]
+
+-- | Binary classification of truth vs. a test result
+classifyBin :: Bool -> Bool -> BinaryClassification
+classifyBin truth test
+    |     truth &&     test = TruePositive
+    | not truth &&     test = FalsePositive
+    |     truth && not test = FalseNegative
+  --  not truth && not test =
+    | otherwise             = TrueNegative
+
+data BinaryClassification =
+    TruePositive  | FalsePositive
+  | FalseNegative | TrueNegative
+  deriving Show
+
+{-------------------------------------------------------------------------------
+  Arbitrary
+-------------------------------------------------------------------------------}
+
+data InMemLookupData k v = InMemLookupData {
+    -- | Data for constructing a run
+    runData :: Map k (Entry v BlobSpan)
+    -- | Lookups, with expected return values
+  , lookups :: [k]
+  }
+  deriving stock (Show, Generic)
+  deriving anyclass NFData
+
+instance Arbitrary (InMemLookupData SerialisedKey SerialisedValue) where
+  arbitrary = liftArbitrary2InMemLookupData genSerialisedKey genSerialisedValue
+  shrink = liftShrink2InMemLookupData shrinkSerialisedKey shrinkSerialisedValue
+
+instance Arbitrary1 (InMemLookupData SerialisedKey) where
+  liftArbitrary = liftArbitrary2InMemLookupData genSerialisedKey
+
+liftArbitrary2InMemLookupData :: Ord k => Gen k -> Gen v -> Gen (InMemLookupData k v)
+liftArbitrary2InMemLookupData genKey genValue = do
+    kops <- liftArbitrary2Map genKey (liftArbitrary genEntry)
+              `suchThat` (\x -> Map.size x > 0)
+    let runData = Map.mapMaybe id kops
+    lookups <- sublistOf (Map.keys kops) >>= shuffle
+    pure InMemLookupData{ runData, lookups }
+  where
+    genEntry = liftArbitrary2 genValue arbitrary
+
+liftShrink2InMemLookupData :: Ord k => (k -> [k]) -> (v -> [v]) -> InMemLookupData k v -> [InMemLookupData k v]
+liftShrink2InMemLookupData shrinkKey shrinkValue InMemLookupData{ runData, lookups } =
+         [ InMemLookupData runData' lookups
+         | runData' <- liftShrink2Map shrinkKey shrinkEntry runData ]
+      ++ [ InMemLookupData runData lookups'
+         | lookups' <- liftShrink shrinkKey lookups ]
+    where
+      shrinkEntry = liftShrink2 shrinkValue shrink
+
+genSerialisedKey :: Gen SerialisedKey
+genSerialisedKey = arbitrary `suchThat` (\k -> sizeofKey k >= 6)
+
+shrinkSerialisedKey :: SerialisedKey -> [SerialisedKey]
+shrinkSerialisedKey k = [k' | k' <- shrink k, sizeofKey k' >= 6]
+
+genSerialisedValue :: Gen SerialisedValue
+genSerialisedValue = frequency [ (50, arbitrary), (1, genLongValue) ]
+  where genLongValue = coerce ((<>) <$> genRawBytesSized 65536 <*> arbitrary)
+
+-- Shrinking as lists can normally be quite slow, so if the value is larger than
+-- a threshold, use less exhaustive shrinking.
+shrinkSerialisedValue :: SerialisedValue -> [SerialisedValue]
+shrinkSerialisedValue v
+  | sizeofValue v > 64 = -- shrink towards fewer bytes
+                          [ coerce RB.takeRawBytes n' v | n' <- shrinkIntegral n ]
+                          -- shrink towards a value of all 0-bytes
+                      ++ [ v' | let v' = coerce (P.fromList $ replicate n 0), v' /= v ]
+  | otherwise          = shrink v -- expensive, but thorough
+  where n = sizeofValue v

--- a/test/Test/Util/QuickCheck.hs
+++ b/test/Test/Util/QuickCheck.hs
@@ -1,0 +1,15 @@
+module Test.Util.QuickCheck (
+    liftArbitrary2Map
+  , liftShrink2Map
+  ) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Test.QuickCheck
+
+liftArbitrary2Map :: Ord k => Gen k -> Gen v -> Gen (Map k v)
+liftArbitrary2Map genk genv = Map.fromList <$> liftArbitrary (liftArbitrary2 genk genv)
+
+liftShrink2Map :: Ord k => (k -> [k]) -> (v -> [v]) -> Map k v -> [Map k v]
+liftShrink2Map shrinkk shrinkv m = Map.fromList <$>
+    liftShrink (liftShrink2 shrinkk shrinkv) (Map.toList m)


### PR DESCRIPTION
Roundtrip test for the in-memory parts: construct a run incrementally from key/value/blob data, then perform lookups on the resulting run (using in-memory raw pages, not actual on-disk pages). 