### PR TITLE
Cache dependencies even if `cabal build` or `cabal test` fails

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
 
     env:
-      ghc: "9.2.8"
-      cabal: "3.10.1.0"
+      ghc: "9.6.4"
+      cabal: "3.10.2.1"
       os: ubuntu-latest"
 
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -52,8 +52,9 @@ jobs:
       run: |
         cabal build all --dry-run
 
-    - name: Cache cabal store
-      uses: actions/cache@v3
+    - name: "Restore cache"
+      uses: actions/cache/restore@v4
+      id: restore-cabal-cache
       env:
         cache-name: cache-cabal-build
       with:
@@ -65,7 +66,16 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install cabal dependencies
+      id: build-dependencies
       run: cabal build --only-dependencies --enable-tests --enable-benchmarks all
+
+    - name: "Save cache"
+      uses: actions/cache/save@v4
+      id: save-cabal-cache
+      if: steps.build-dependencies.outcome == 'success' && steps.restore-cabal-cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup-haskell.outputs.cabal-store }}
+        key:  ${{ steps.restore-cabal-cache.outputs.cache-primary-key }}
 
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -22,13 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8", "9.4.7", "9.6.3"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.2.8", "9.4.8", "9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
-          - ghc: "9.4.7"
+          - ghc: "9.4.8"
             os: windows-latest
-          - ghc: "9.4.7"
+          - ghc: "9.4.8"
             os: macOS-latest
 
     steps:
@@ -72,6 +72,9 @@ jobs:
     - name: "Save cache"
       uses: actions/cache/save@v4
       id: save-cabal-cache
+      # Note: cache-hit will be set to true only when cache hit occurs for the
+      # exact key match. For a partial key match via restore-keys or a cache
+      # miss, it will be set to false.
       if: steps.build-dependencies.outcome == 'success' && steps.restore-cabal-cache.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
@@ -90,8 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
     steps:
@@ -130,7 +133,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install stylish-haskell
-      run: cabal install stylish-haskell --constraint 'stylish-haskell == 0.14.4.0'
+      run: cabal install stylish-haskell --constraint 'stylish-haskell == 0.14.6.0'
 
     - name: Record stylish-haskell version
       run: |
@@ -149,8 +152,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
     steps:
@@ -189,7 +192,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.ghc }}-${{ env.cache-name }}-
 
     - name: Install cabal-fmt
-      run: cabal install cabal-fmt --constraint 'cabal-fmt == 0.1.7'
+      run: cabal install cabal-fmt --constraint 'cabal-fmt == 0.1.10'
 
     - name: Record cabal-fmt version
       run: |
@@ -208,8 +211,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.2"]
-        cabal: ["3.10.1.0"]
+        ghc: ["9.6.4"]
+        cabal: ["3.10.2.1"]
         os: [ubuntu-latest]
 
     steps:

--- a/cabal.project
+++ b/cabal.project
@@ -12,10 +12,11 @@ repository cardano-haskell-packages
 
 index-state:
   -- Bump this if you need newer packages from Hackage
-  -- current date: quickcheck-lockstep-0.3.0
-  , hackage.haskell.org 2023-10-23T09:21:38Z
+  -- current date: stylish-haskell-0.14.6.0
+  , hackage.haskell.org 2024-01-19T13:48:53Z
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2023-09-20T00:00:00Z
+  -- current date: fs-api-0.2.0.1, fs-sim-0.2.1.1
+  , cardano-haskell-packages 2023-11-30T09:59:24Z
 
 packages: .
 


### PR DESCRIPTION
Also: update index-states and update versions for GHC, Cabal, `stylish-haskell`, `cabal-fmt`