### PR TITLE
Add benchmarks for skewed k-way merge

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -255,12 +255,13 @@ test-suite kmerge-test
     , deepseq
     , heaps
     , lsm-tree:kmerge
+    , primitive
     , splitmix
     , tasty
     , tasty-bench
     , tasty-hunit
     , tasty-quickcheck
-    , wide-word
+    , vector
 
 test-suite map-range-test
   import:           warnings, wno-x-partial

--- a/test/kmerge-test.hs
+++ b/test/kmerge-test.hs
@@ -24,11 +24,11 @@ import qualified KMerge.Heap as K.Heap
 import qualified KMerge.LoserTree as K.Tree
 
 -- tests and benchmarks for various k-way merge implementations.
--- in short: loser tree is optimal in comparision counts performed,
+-- in short: loser tree is optimal in comparison counts performed,
 -- but mutable heap implementation has lower constant factors.
 --
 -- Noteworthy, maybe not obvious observations:
--- - mutable heap does the same amount of comparisions as persistent heap
+-- - mutable heap does the same amount of comparisons as persistent heap
 --   (from @heaps@ package),
 -- - tree-shaped iterative two-way merge performs optimal amount of comparisons
 --   loser tree is an explicit state variant of that.
@@ -64,9 +64,9 @@ main = do
                     , testCount "loserTreeMerge"  2391 loserTreeMerge    input8
                     , testCount "mutHeapMerge"    3169 mutHeapMerge      input8
                     ]
-                    -- seven inputs: we have 6x100 elements with 3 comparisions
+                    -- seven inputs: we have 6x100 elements with 3 comparisons
                     -- and 1x100 elements with just 2.
-                    -- i.e. target is 2000 total comparisions.
+                    -- i.e. target is 2000 total comparisons.
                     --
                     -- The difference here and in five-input case between
                     -- treeMerge and loserTreeMerge is caused by
@@ -106,7 +106,7 @@ main = do
                     ]
                     -- five inputs: we have 3x100 elements with 2 comparisons
                     -- and 2x100 with 3 comparisons.
-                    -- i.e. target is 1200 total comparisions.
+                    -- i.e. target is 1200 total comparisons.
                 , testGroup "five"
                     [ testCount "sortConcat"      1790 (L.sort . concat) input5
                     , testCount "listMerge"       1389 listMerge         input5


### PR DESCRIPTION
I get the following results (but also look at the comparison counts please):

```
  bench
    eight
      sortConcat:       OK (0.26s)
        62.5 μs ± 3.3 μs
      listMerge:        OK (0.18s)
        43.7 μs ± 2.9 μs
      treeMerge:        OK (0.15s)
        34.7 μs ± 2.8 μs
      heapMerge:        OK (0.80s)
        96.8 μs ± 3.0 μs
      loserTreeMerge:   OK (0.13s)
        29.4 μs ± 2.8 μs
      mutHeapMerge:     OK (0.21s)
        24.8 μs ± 2.1 μs
    seven
      sortConcat:       OK (0.20s)
        47.7 μs ± 3.3 μs
      listMerge:        OK (0.14s)
        33.9 μs ± 3.0 μs
      treeMerge:        OK (0.46s)
        27.6 μs ± 2.5 μs
      heapMerge:        OK (0.17s)
        80.4 μs ± 6.5 μs
      loserTreeMerge:   OK (0.21s)
        24.6 μs ± 1.4 μs
      mutHeapMerge:     OK (0.34s)
        20.7 μs ± 921 ns
    five
      sortConcat:       OK (0.91s)
        27.8 μs ± 733 ns
      listMerge:        OK (0.14s)
        16.8 μs ± 1.6 μs
      treeMerge:        OK (0.13s)
        15.4 μs ± 1.4 μs
      heapMerge:        OK (0.20s)
        47.2 μs ± 2.8 μs
      loserTreeMerge:   OK (0.43s)
        13.1 μs ± 979 ns
      mutHeapMerge:     OK (0.44s)
        13.2 μs ± 438 ns
    levelling-min
      sortConcat:       OK (0.12s)
        57.1 μs ± 5.3 μs
      listMerge:        OK (0.12s)
        29.6 μs ± 2.9 μs
      treeMerge:        OK (0.27s)
        32.9 μs ± 1.5 μs
      heapMerge:        OK (0.36s)
        87.5 μs ± 4.8 μs
      loserTreeMerge:   OK (0.13s)
        30.4 μs ± 2.9 μs
      skewedMerge:      OK (0.22s)
        26.5 μs ± 1.6 μs
      mutHeapMerge:     OK (0.23s)
        27.8 μs ± 1.7 μs
    levelling-max
      sortConcat:       OK (0.22s)
        52.3 μs ± 4.9 μs
      listMerge:        OK (0.15s)
        17.9 μs ± 1.5 μs
      treeMerge:        OK (0.25s)
        30.2 μs ± 1.6 μs
      heapMerge:        OK (0.25s)
        59.6 μs ± 4.3 μs
      loserTreeMerge:   OK (0.22s)
        26.1 μs ± 2.1 μs
      skewedMerge:      OK (0.28s)
        16.9 μs ± 1.0 μs
      mutHeapMerge:     OK (0.19s)
        22.2 μs ± 1.6 μs
```

For skewed inputs, `mutHeapMerge` is faster (in this microbenchmark) than `loserTreeMerge`, but the number of comparisons is still worse. In particular, it shows significantly more comparisons than the pure heap implementation from the `heaps` package.

A combination of loser tree merge (for the short inputs) and plain list merge (final merge with long input) performs best both in comparison count and runtime.

This suggests that for out levelling merge usecase:
1. there might still be potential for the mutable heap implementation to reduce comparisons
2. a loser tree with a skewed tree structure could perform very well