### PR TITLE
Rename Integration module to Lookup module

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/Lookup.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {- HLINT ignore "Use const" -}
 
-module Bench.Database.LSMTree.Internal.Integration (benchmarks, analysis) where
+module Bench.Database.LSMTree.Internal.Lookup (benchmarks, analysis) where
 
 import           Bench.Database.LSMTree.Internal.Run.BloomFilter (elems)
 import           Bench.Database.LSMTree.Internal.Run.Index.Compact (searches)
@@ -23,7 +23,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromMaybe)
 import           Data.Proxy (Proxy (..))
 import           Database.LSMTree.Generators (RFPrecision (..), UTxOKey)
-import           Database.LSMTree.Internal.Integration (prepLookups)
+import           Database.LSMTree.Internal.Lookup (prepLookups)
 import           Database.LSMTree.Internal.Run.BloomFilter (Bloom)
 import qualified Database.LSMTree.Internal.Run.BloomFilter as Bloom
 import           Database.LSMTree.Internal.Run.Index.Compact (Append (..),
@@ -42,7 +42,7 @@ import           Text.Printf (printf)
 
 -- | TODO: add a separate micro-benchmark that includes multi-pages.
 benchmarks :: Benchmark
-benchmarks = bgroup "Bench.Database.LSMTree.Internal.Integration" [
+benchmarks = bgroup "Bench.Database.LSMTree.Internal.Lookup" [
       bgroup "prepLookups for a single run" [
           benchPrepLookups defaultConfig
         , benchPrepLookups (defaultConfig {

--- a/bench/micro/Main.hs
+++ b/bench/micro/Main.hs
@@ -9,7 +9,7 @@
 --
 module Main (main) where
 
-import qualified Bench.Database.LSMTree.Internal.Integration
+import qualified Bench.Database.LSMTree.Internal.Lookup
 import qualified Bench.Database.LSMTree.Internal.RawPage
 import qualified Bench.Database.LSMTree.Internal.Run.BloomFilter
 import qualified Bench.Database.LSMTree.Internal.Run.Index.Compact
@@ -17,7 +17,7 @@ import           Criterion.Main (defaultMain)
 
 main :: IO ()
 main = defaultMain [
-      Bench.Database.LSMTree.Internal.Integration.benchmarks
+      Bench.Database.LSMTree.Internal.Lookup.benchmarks
     , Bench.Database.LSMTree.Internal.Run.BloomFilter.benchmarks
     , Bench.Database.LSMTree.Internal.Run.Index.Compact.benchmarks
     , Bench.Database.LSMTree.Internal.RawPage.benchmarks

--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -44,8 +44,8 @@ library
     Database.LSMTree.Internal.BlobRef
     Database.LSMTree.Internal.CRC32C
     Database.LSMTree.Internal.Entry
-    Database.LSMTree.Internal.Integration
     Database.LSMTree.Internal.KMerge
+    Database.LSMTree.Internal.Lookup
     Database.LSMTree.Internal.Monoidal
     Database.LSMTree.Internal.Normal
     Database.LSMTree.Internal.RawPage
@@ -205,7 +205,7 @@ benchmark lsm-tree-micro-bench
   hs-source-dirs:   bench/micro
   main-is:          Main.hs
   other-modules:
-    Bench.Database.LSMTree.Internal.Integration
+    Bench.Database.LSMTree.Internal.Lookup
     Bench.Database.LSMTree.Internal.RawPage
     Bench.Database.LSMTree.Internal.Run.BloomFilter
     Bench.Database.LSMTree.Internal.Run.Index.Compact

--- a/src/Database/LSMTree/Internal/Lookup.hs
+++ b/src/Database/LSMTree/Internal/Lookup.hs
@@ -1,32 +1,4 @@
--- | Integration of LSM-Tree components into a full levels structure.
---
--- === TODO
---
--- This is temporary module header documentation. The module will be
--- fleshed out more as we implement bits of it.
---
--- Related work packages: 7
---
--- This module includes in-memory parts and I\/O parts for, amongst others,
---
--- * LSM table handles (multiple runs in multiple levels)
---
--- * Opening and verifying a table
---
--- * Updates (inserts, deletes, mupserts)
---
--- * High performance batch lookups in multiple runs
---
--- * Range lookups
---
--- * Flushing the write buffer when full
---
--- * Merging of runs and levels
---
--- The above list is a sketch. Functionality may move around, and the list is
--- not exhaustive.
---
-module Database.LSMTree.Internal.Integration (
+module Database.LSMTree.Internal.Lookup (
     Run
   , prepLookups
   ) where


### PR DESCRIPTION
It's probably useful to have a module that is dedicated just to lookups