### PR TITLE
Change RawPage lookup to handle overflow case

### DIFF
--- a/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
+++ b/bench/micro/Bench/Database/LSMTree/Internal/RawPage.hs
@@ -23,9 +23,9 @@ import           Test.QuickCheck.Random (mkQCGen)
 
 benchmarks :: Benchmark
 benchmarks = rawpage `deepseq` bgroup "Bench.Database.LSMTree.Internal.RawPage"
-    [ bench "missing" $ nf (rawPageEntry rawpage) missing
-    , bench "existing-head" $ nf (rawPageEntry rawpage) existingHead
-    , bench "existing-last" $ nf (rawPageEntry rawpage) existingLast
+    [ bench "missing" $ whnf (rawPageLookup rawpage) missing
+    , bench "existing-head" $ whnf (rawPageLookup rawpage) existingHead
+    , bench "existing-last" $ whnf (rawPageLookup rawpage) existingLast
     ]
   where
     page :: PageLogical

--- a/doc/format-page.md
+++ b/doc/format-page.md
@@ -236,7 +236,8 @@ index of the blob reference.
 
 This is an array of 16bit values. There are N entries. Entry i (indexed from 0)
 gives the offset within the page of the start of the key byte string. Entry i+1
-therefore gives the offset one past each key. This provides a span for the key.
+therefore gives the offset one past each key. This provides a span for each key:
+each one represented by an inclusive lower offset and an exclusive upper offset.
 For the final key, key N-1, we can still use N-1 and N, even though there are
 only N entries, because we arrange that the value offset array comes
 immediately after the key offset array, and the first entry of the value offset
@@ -247,11 +248,13 @@ come immediately after the key byte strings).
 
 Except for the special case of N=1, this is an array of 16bit values, with N+1
 entries. In the usual case, we can find the value byte string span from index
-i and i+1.
+i and i+1. As above, the spans are represented by an inclusive lower offset and
+an exclusive upper offset.
 
 For the special case of N=1, the representation is two offsets, but the second
 offset is 32bit rather than 16bit. This is to allow for very large values that
-take more than one page (or indeed more than 64k).
+take more than one page (or indeed more than 64k). As with all other spans, it
+uses inclusive lower and exclusive upper representation.
 
 Note that the 32bit value will still be naturally aligned, because the key
 offset array is aligned to 32bit, and for N=1, the value offset array will be

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE DeriveFunctor  #-}
 {-# LANGUAGE NamedFieldPuns #-}
 module Database.LSMTree.Internal.RawPage (
     RawPage,
     makeRawPage,
+    rawPageRawBytes,
     rawPageNumKeys,
     rawPageNumBlobs,
-    rawPageEntry,
-    rawPageValue1Prefix,
+    rawPageLookup,
+    RawPageLookup(..),
     -- * Debug
     rawPageKeyOffsets,
     rawPageValueOffsets,
@@ -29,6 +31,7 @@ import qualified Data.Vector.Primitive as P
 import           Data.Word (Word16, Word32, Word64, Word8)
 import           Database.LSMTree.Internal.BlobRef (BlobSpan (..))
 import           Database.LSMTree.Internal.Entry (Entry (..))
+import           Database.LSMTree.Internal.Serialise.RawBytes (RawBytes (..))
 import           GHC.List (foldl')
 
 -------------------------------------------------------------------------------
@@ -57,54 +60,93 @@ makeRawPage
     -> RawPage
 makeRawPage ba off = RawPage (div2 off) ba
 
+rawPageRawBytes :: RawPage -> RawBytes
+rawPageRawBytes (RawPage off ba) =
+    RawBytes (P.Vector (mul2 off) 4096 ba)
+
 -------------------------------------------------------------------------------
 -- Lookup function
 -------------------------------------------------------------------------------
 
-rawPageEntry
+data RawPageLookup entry =
+       -- | The key is not present on the page.
+       LookupEntryNotPresent
+
+       -- | The key is present and corresponds to a normal entry that fits
+       -- fully within the page.
+     | LookupEntry !entry
+
+       -- | The key is present and corresponds to an entry where the value
+       -- may have overflowed onto subsequent pages. In this case the entry
+       -- contains the /prefix/ of the value (that did fit on the page). The
+       -- length of the suffix is returned separately.
+     | LookupEntryOverflow !entry !Word32
+  deriving (Eq, Functor, Show)
+
+rawPageLookup
     :: RawPage
     -> P.Vector Word8 -- ^ key
-    -> Maybe (Entry (P.Vector Word8) BlobSpan)
-rawPageEntry !page !key = bisect 0 (fromIntegral dirNumKeys)
+    -> RawPageLookup (Entry (P.Vector Word8) BlobSpan)
+rawPageLookup !page !key
+  | dirNumKeys == 1 = lookup1
+  | otherwise       = bisect 0 (fromIntegral dirNumKeys)
   where
     !dirNumKeys = rawPageNumKeys page
+
+    lookup1
+      | key == rawPageKeyAt page 0
+      = let !entry  = rawPageEntry1 page
+            !suffix = rawPageSingleValueSuffix page
+         in if suffix > 0
+              then LookupEntryOverflow entry suffix
+              else LookupEntry         entry
+      | otherwise
+      = LookupEntryNotPresent
 
     -- when to switch to linear scan
     -- this a tuning knob
     -- can be set to zero.
     threshold = 3
 
-    found :: Int -> Maybe (Entry (P.Vector Word8) BlobSpan)
-    found !i = Just $! case rawPageOpAt page i of
-        0 -> if rawPageHasBlobSpanAt page i == 0
-             then Insert (rawPageValueAt page i)
-             else InsertWithBlob (rawPageValueAt page i) (rawPageBlobSpanIndex page (rawPageCalculateBlobIndex page i))
-        1 -> Mupdate (rawPageValueAt page i)
-        _ -> Delete
-
-    bisect :: Int -> Int -> Maybe (Entry (P.Vector Word8) BlobSpan)
+    bisect :: Int -> Int -> RawPageLookup (Entry (P.Vector Word8) BlobSpan)
     bisect !i !j
         | j - i < threshold = linear i j
         | otherwise = case compare key (rawPageKeyAt page k) of
-            EQ -> found k
+            EQ -> LookupEntry (rawPageEntryAt page k)
             GT -> bisect (k + 1) j
             LT -> bisect i k
       where
         k = i + div2 (j - i)
 
-    linear :: Int -> Int -> Maybe (Entry (P.Vector Word8) BlobSpan)
+    linear :: Int -> Int -> RawPageLookup (Entry (P.Vector Word8) BlobSpan)
     linear !i !j
-        | i >= j                       = Nothing
-        | key == rawPageKeyAt page i   = found i
-        | otherwise                    = linear (i + 1) j
+        | i >= j                     = LookupEntryNotPresent
+        | key == rawPageKeyAt page i = LookupEntry (rawPageEntryAt page i)
+        | otherwise                  = linear (i + 1) j
 
-rawPageValue1Prefix :: RawPage -> Entry (P.Vector Word8, Word32) BlobSpan
-rawPageValue1Prefix page = case rawPageOpAt page 0 of
-  0 -> if rawPageHasBlobSpanAt page 0 == 0
-       then Insert (rawPageSingleValue page)
-       else InsertWithBlob (rawPageSingleValue page) (rawPageBlobSpanIndex page (rawPageCalculateBlobIndex page 0))
-  1 -> Mupdate (rawPageSingleValue page)
-  _ -> Delete
+-- | for non-single key page case
+rawPageEntryAt :: RawPage -> Int -> Entry (P.Vector Word8) BlobSpan
+rawPageEntryAt page i =
+    case rawPageOpAt page i of
+      0 -> if rawPageHasBlobSpanAt page i == 0
+           then Insert (rawPageValueAt page i)
+           else InsertWithBlob (rawPageValueAt page i)
+                               (rawPageBlobSpanIndex page
+                                  (rawPageCalculateBlobIndex page i))
+      1 -> Mupdate (rawPageValueAt page i)
+      _ -> Delete
+
+-- | single key page case
+rawPageEntry1 :: RawPage -> Entry (P.Vector Word8) BlobSpan
+rawPageEntry1 page =
+    case rawPageOpAt page 0 of
+      0 -> if rawPageHasBlobSpanAt page 0 == 0
+           then Insert (rawPageSingleValuePrefix page)
+           else InsertWithBlob (rawPageSingleValuePrefix page)
+                               (rawPageBlobSpanIndex page
+                                  (rawPageCalculateBlobIndex page 0))
+      1 -> Mupdate (rawPageSingleValuePrefix page)
+      _ -> Delete
 
 -------------------------------------------------------------------------------
 -- Accessors
@@ -143,6 +185,7 @@ rawPageValueOffsets page@(RawPage off ba) =
     !dirOffset  = rawPageKeysOffset page
 
 -- | single key page case
+{-# INLINE rawPageValueOffsets1 #-}
 rawPageValueOffsets1 :: RawPage -> (Word16, Word32)
 rawPageValueOffsets1 page@(RawPage off ba) =
     assert (rawPageNumKeys page == 1) $
@@ -212,13 +255,21 @@ rawPageValueAt page@(RawPage off ba) i = do
     start = fromIntegral (P.unsafeIndex offs i) :: Int
     end   = fromIntegral (P.unsafeIndex offs (i + 1)) :: Int
 
-rawPageSingleValue :: RawPage -> (P.Vector Word8, Word32)
-rawPageSingleValue page@(RawPage off ba) =
-    if end > 4096
-    then (P.Vector (mul2 off + fromIntegral start) (4096 - fromIntegral start) ba, end - 4096)
-    else (P.Vector (mul2 off + fromIntegral start) (fromIntegral end - fromIntegral start) ba, 0)
+rawPageSingleValuePrefix :: RawPage -> P.Vector Word8
+rawPageSingleValuePrefix page@(RawPage off ba) =
+    P.Vector (mul2 off + fromIntegral start)
+             (fromIntegral prefix_end - fromIntegral start)
+             ba
   where
     (start, end) = rawPageValueOffsets1 page
+    prefix_end   = min 4096 end
+
+rawPageSingleValueSuffix :: RawPage -> Word32
+rawPageSingleValueSuffix page
+    | end > 4096 = end - 4096
+    | otherwise  = 0
+  where
+    (_, end) = rawPageValueOffsets1 page
 
 -- we could create unboxed array.
 {-# INLINE rawPageBlobSpanIndex #-}

--- a/src/Database/LSMTree/Internal/RawPage.hs
+++ b/src/Database/LSMTree/Internal/RawPage.hs
@@ -19,6 +19,7 @@ module Database.LSMTree.Internal.RawPage (
 ) where
 
 import           Control.DeepSeq (NFData (rnf))
+import           Control.Exception (assert)
 import           Data.Bits (Bits, complement, popCount, unsafeShiftL,
                      unsafeShiftR, (.&.))
 import           Data.Primitive.ByteArray (ByteArray (..), indexByteArray,
@@ -134,6 +135,7 @@ rawPageKeyOffsets page@(RawPage off ba) =
 -- | for non-single key page case
 rawPageValueOffsets :: RawPage -> P.Vector ValueOffset
 rawPageValueOffsets page@(RawPage off ba) =
+    assert (dirNumKeys /= 1) $
     P.Vector (off + fromIntegral (div2 dirOffset) + fromIntegral dirNumKeys)
              (fromIntegral dirNumKeys + 1) ba
   where
@@ -143,6 +145,7 @@ rawPageValueOffsets page@(RawPage off ba) =
 -- | single key page case
 rawPageValueOffsets1 :: RawPage -> (Word16, Word32)
 rawPageValueOffsets1 page@(RawPage off ba) =
+    assert (rawPageNumKeys page == 1) $
     ( indexByteArray ba (off + fromIntegral (div2 dirOffset) + 1)
     , indexByteArray ba (div2 (off + fromIntegral (div2 dirOffset)) + 1)
     )

--- a/src/Database/LSMTree/Internal/Run/Construction.hs
+++ b/src/Database/LSMTree/Internal/Run/Construction.hs
@@ -26,6 +26,13 @@ module Database.LSMTree.Internal.Run.Construction (
   , paEmpty
   , paAddElem
   , paSingleton
+    -- ** Page size
+  , PageSize(..)
+  , psEmpty
+  , psIsEmpty
+  , psIsOverfull
+  , psAddElem
+  , psSingleton
     -- * Exposed only for testing
     -- ** StricterList
   , StricterList (..)


### PR DESCRIPTION
Previously the rawPageEntry was designed to cover the case where everything fit onto a single page (though it actually worked and was tested for cases where it overflowed into immediately subsequent memory, provided the value end offset remained within 16bits).
    
Now the renamed rawPageLookup can return either LookupEntryNormal or LookupEntryOverflow. In the latter case it returns the value prefix and it also returns the length of the trailing suffix that needs to be fetched from other subsequent pages.
    
This means there's no pre-condition on rawPageLookup that it not be a single-entry page.
    
Update the tests correspondingly.