### PR TITLE
Add HasCallStack to RawBytes.unsafeFromRawBytes

### DIFF
--- a/src/Database/LSMTree/Internal/Serialise/Class.hs
+++ b/src/Database/LSMTree/Internal/Serialise/Class.hs
@@ -54,7 +54,7 @@ serialiseKeyMinimalSize x = sizeofRawBytes (serialiseKey x) >= 6
 -- Instances should satisfy the following:
 --
 -- [Identity] @'deserialiseValue' ('serialiseValue' x) == x@
--- [Concat distributes] @'deserialiseValueN' xs == 'deserialiseValue' ('RawBytes.concat' xs)@
+-- [Concat distributes] @'deserialiseValueN' xs == 'deserialiseValue' ('mconcat' xs)@
 class SerialiseValue v where
   serialiseValue :: v -> RawBytes
   deserialiseValue :: RawBytes -> v
@@ -67,4 +67,4 @@ serialiseValueIdentity x = deserialiseValue (serialiseValue x) == x
 
 -- | Test the __Concat distributes__ law for the 'SerialiseValue' class
 serialiseValueConcatDistributes :: forall v. (Eq v, SerialiseValue v) => Proxy v -> [RawBytes] -> Bool
-serialiseValueConcatDistributes _ xs = deserialiseValueN @v xs == deserialiseValue (RawBytes.concat xs)
+serialiseValueConcatDistributes _ xs = deserialiseValueN @v xs == deserialiseValue (mconcat xs)

--- a/test/Test/Database/LSMTree/Internal/Serialise.hs
+++ b/test/Test/Database/LSMTree/Internal/Serialise.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Vector.Primitive as P
 import           Data.Word
 import           Database.LSMTree.Internal.Serialise
-import           Database.LSMTree.Internal.Serialise.RawBytes hiding ((++))
+import           Database.LSMTree.Internal.Serialise.RawBytes
 import           Database.LSMTree.Util (showPowersOf10)
 import           Test.Tasty
 import           Test.Tasty.HUnit


### PR DESCRIPTION
As the module is import *both* qualified and unqualified, I went ahead and removed/renamed (++), concat and take, as I spend an hour wondering what's wrong with ++.