### PR TITLE
Rawpage test comparison

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -167,9 +167,11 @@ test-suite lsm-tree-test
     Test.Database.LSMTree.Normal.StateMachine
     Test.Database.LSMTree.Normal.StateMachine.Op
     Test.Util.Orphans
+    Test.Util.RawPage
     Test.Util.TypeFamilyWrappers
 
   build-depends:
+    , ansi-terminal
     , base                                                          >=4.16 && <4.20
     , bitvec
     , bytestring
@@ -193,12 +195,14 @@ test-suite lsm-tree-test
     , quickcheck-instances
     , quickcheck-lockstep
     , random
+    , semialign
     , split
     , stm
     , tasty
     , tasty-hunit
     , tasty-quickcheck
     , temporary
+    , these
     , transformers
     , vector
 

--- a/src/Database/LSMTree/Internal/BitMath.hs
+++ b/src/Database/LSMTree/Internal/BitMath.hs
@@ -2,19 +2,28 @@
 --
 -- Valid for non-negative arguments.
 module Database.LSMTree.Internal.BitMath (
+    -- * Two
     div2,
     mod2,
     mul2,
     ceilDiv2,
+    -- * Four
     div4,
     mod4,
     mul4,
+    -- * Eight
     div8,
     mod8,
     mul8,
     ceilDiv8,
+    -- * Sixteen
+    div16,
+    mod16,
+    mul16,
+    -- * 32
     div32,
     mod32,
+    -- * 64
     div64,
     mod64,
     mul64,
@@ -22,6 +31,10 @@ module Database.LSMTree.Internal.BitMath (
 ) where
 
 import           Data.Bits
+
+-------------------------------------------------------------------------------
+-- 2
+-------------------------------------------------------------------------------
 
 div2 :: Bits a => a -> a
 div2 x = unsafeShiftR x 1
@@ -39,6 +52,10 @@ ceilDiv2 :: (Bits a, Num a) => a -> a
 ceilDiv2 i = unsafeShiftR (i + 1) 1
 {-# INLINE ceilDiv2 #-}
 
+-------------------------------------------------------------------------------
+-- 4
+-------------------------------------------------------------------------------
+
 div4 :: Bits a => a -> a
 div4 x = unsafeShiftR x 2
 {-# INLINE div4 #-}
@@ -50,6 +67,10 @@ mod4 x = x .&. 3
 mul4 :: Bits a => a -> a
 mul4 x = unsafeShiftL x 2
 {-# INLINE mul4 #-}
+
+-------------------------------------------------------------------------------
+-- 8
+-------------------------------------------------------------------------------
 
 div8 :: Bits a => a -> a
 div8 x = unsafeShiftR x 3
@@ -67,6 +88,26 @@ ceilDiv8 :: (Bits a, Num a) => a -> a
 ceilDiv8 i = unsafeShiftR (i + 7) 3
 {-# INLINE ceilDiv8 #-}
 
+-------------------------------------------------------------------------------
+-- 16
+-------------------------------------------------------------------------------
+
+div16 :: Bits a => a -> a
+div16 x = unsafeShiftR x 4
+{-# INLINE div16 #-}
+
+mod16 :: (Bits a, Num a) => a -> a
+mod16 x = x .&. 15
+{-# INLINE mod16 #-}
+
+mul16 :: Bits a => a -> a
+mul16 x = unsafeShiftL x 4
+{-# INLINE mul16 #-}
+
+-------------------------------------------------------------------------------
+-- 32
+-------------------------------------------------------------------------------
+
 div32 :: Bits a => a -> a
 div32 x = unsafeShiftR x 5
 {-# INLINE div32 #-}
@@ -74,6 +115,10 @@ div32 x = unsafeShiftR x 5
 mod32 :: (Bits a, Num a) => a -> a
 mod32 x = x .&. 31
 {-# INLINE mod32 #-}
+
+-------------------------------------------------------------------------------
+-- 64
+-------------------------------------------------------------------------------
 
 -- |
 --

--- a/test/Test/Util/RawPage.hs
+++ b/test/Test/Util/RawPage.hs
@@ -1,0 +1,108 @@
+module Test.Util.RawPage (
+    toRawPage,
+    assertEqualRawPages,
+) where
+
+import           Control.Monad (unless)
+import           Data.Align (align)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
+import           Data.List.Split (chunksOf)
+import           Data.Primitive.ByteArray (ByteArray (..))
+import           Data.These (These (..))
+import           Data.Word (Word8)
+import           Database.LSMTree.Internal.BitMath (div16, mod16)
+import           Database.LSMTree.Internal.RawPage (RawPage, makeRawPage,
+                     rawPageRawBytes)
+import qualified Database.LSMTree.Internal.Serialise.RawBytes as RB
+import           FormatPage (PageLogical, encodePage, serialisePage)
+import qualified System.Console.ANSI as ANSI
+import           Test.Tasty.HUnit (Assertion, assertFailure)
+
+-- | Convert prototype 'PageLogical' to 'RawPage'.
+toRawPage :: PageLogical -> (RawPage, BS.ByteString)
+toRawPage p = (page, sfx)
+  where
+    bs = serialisePage $ encodePage p
+    (pfx, sfx) = BS.splitAt 4096 bs -- hardcoded page size.
+    page = case SBS.toShort pfx of SBS.SBS ba -> makeRawPage (ByteArray ba) 0
+
+assertEqualRawPages :: RawPage -> RawPage -> Assertion
+assertEqualRawPages a b = unless (a == b) $ do
+    assertFailure $ "unequal pages:\n" ++ ANSI.setSGRCode [ANSI.Reset] ++ compareBytes (RB.unpack (rawPageRawBytes a)) (RB.unpack (rawPageRawBytes b))
+
+-- Print two bytestreams next to each other highlighting the differences.
+compareBytes :: [Word8] -> [Word8] -> String
+compareBytes xs ys = unlines $ go (grouping chunks)
+  where
+    go :: [Either [()] [([Word8], [Word8])]] -> [String]
+    go []                = []
+    go (Left _ : zs)     = "..." : go zs
+    go (Right diff : zs) = map (uncurry showDiff) diff ++ go zs
+
+    showDiff :: [Word8] -> [Word8] -> String
+    showDiff = aux id id where
+        aux :: ShowS -> ShowS ->  [Word8] -> [Word8] -> String
+        aux accl accr []     []     = accl . showString "  " . accr $ ""
+        aux accl accr []     rs     = accl . showString "  " . accr . green (concatMapS showsWord8 rs) $ ""
+        aux accl accr ls     []     = accl . red (concatMapS showsWord8 ls) . showString "  " . accr $ ""
+        aux accl accr (l:ls) (r:rs)
+            | l == r                = aux (accl . showsWord8 l) (accr . showsWord8 r) ls rs
+            | otherwise             = aux (accl . red (showsWord8 l)) (accr . green (showsWord8 r)) ls rs
+
+    -- chunks are either equal, or not
+    chunks :: [Either () ([Word8], [Word8])]
+    chunks =
+        [ case b of
+            These x y
+                | x == y    -> Left  ()
+                | otherwise -> Right (x, y)
+            This x -> Right (x, [])
+            That y -> Right ([], y)
+        | b <- align (chunksOf 16 xs) (chunksOf 16 ys)
+        ]
+
+sgr :: [ANSI.SGR] -> ShowS
+sgr cs = (ANSI.setSGRCode cs ++)
+
+red :: ShowS -> ShowS
+red s = sgr [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Red] . s . sgr [ANSI.Reset]
+
+green :: ShowS -> ShowS
+green s = sgr [ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Green] . s . sgr [ANSI.Reset]
+
+concatMapS :: (a -> ShowS) -> [a] -> ShowS
+concatMapS f xs = \acc -> foldr (\a acc' -> f a acc') acc xs
+
+showsWord8 :: Word8 -> ShowS
+showsWord8 w = \acc -> hexdigit (div16 w) : hexdigit (mod16 w) : acc
+
+grouping :: [Either a b] -> [Either [a] [b]]
+grouping = foldr add []
+  where
+    add (Left x)       []                = [Left [x]]
+    add (Right y)      []                = [Right [y]]
+    add (Left x)       (Left xs  : rest) = Left (x : xs) : rest
+    add (Right y) rest@(Left _   : _)    = Right [y] : rest
+    add (Left x)  rest@(Right _  : _ )   = Left [x] : rest
+    add (Right y)      (Right ys : rest) = Right (y:ys) : rest
+
+
+hexdigit :: (Num a, Eq a) => a -> Char
+hexdigit 0x0 = '0'
+hexdigit 0x1 = '1'
+hexdigit 0x2 = '2'
+hexdigit 0x3 = '3'
+hexdigit 0x4 = '4'
+hexdigit 0x5 = '5'
+hexdigit 0x6 = '6'
+hexdigit 0x7 = '7'
+hexdigit 0x8 = '8'
+hexdigit 0x9 = '9'
+hexdigit 0xA = 'a'
+hexdigit 0xB = 'b'
+hexdigit 0xC = 'c'
+hexdigit 0xD = 'd'
+hexdigit 0xE = 'e'
+hexdigit 0xF = 'f'
+hexdigit _   = '?'


### PR DESCRIPTION
The failing test output would look something like

![Screenshot from 2024-03-05 17-59-37](https://github.com/input-output-hk/lsm-tree/assets/51087/45e587b0-5456-4a88-b22a-4265075c39bd)

Helps to figure out which bytes are wrong a lot easier.
