### PR TITLE
Optimise SerialiseKey Word256

### DIFF
--- a/lsm-tree.cabal
+++ b/lsm-tree.cabal
@@ -131,6 +131,7 @@ library lsm-tree-utils
     , containers
     , deepseq
     , lsm-tree:{lsm-tree, bloomfilter}
+    , primitive
     , QuickCheck
     , quickcheck-instances
     , random


### PR DESCRIPTION
From

```
Benchmarking baseline ... 
(This is the cost of just computing the keys.)
Finished.
Time total:        4.93 seconds
Alloc net per key: 4736.00 bytes
```

to

```
Benchmarking baseline ... 
(This is the cost of just computing the keys.)
Finished.
Time total:        0.12 seconds
Alloc net per key: 48.00 bytes
```