### PR TITLE
Add bangs to elemCheapHashes

### DIFF
--- a/bloomfilter/Data/BloomFilter.hs
+++ b/bloomfilter/Data/BloomFilter.hs
@@ -172,7 +172,7 @@ elem :: Hashable a => a -> Bloom a -> Bool
 elem elt ub = elemCheapHashes (makeCheapHashes elt) ub
 
 elemCheapHashes :: CheapHashes a -> Bloom a -> Bool
-elemCheapHashes ch ub = go 0 where
+elemCheapHashes !ch !ub = go 0 where
   go :: Int -> Bool
   go !i | i >= hashesN ub = True
         | otherwise       = let !idx = fromIntegral (evalCheapHashes ch i)`rem` size ub :: Int


### PR DESCRIPTION
```
Benchmarking elemCheapHashes ...
(this is the simple one-by-one lookup, less the cost of computing and hashing the keys)
Finished.
Time total:        39.04 seconds
Alloc total:       1.20e11 bytes
Time net:          33.14 seconds
Alloc net:         0.00 bytes
Time net per key:  1.33e-6 seconds
Alloc net per key: 0.00 bytes
```

Notice: `Alloc net per key: 0.00 bytes`

GHC doesn't see that `elemCheapHashes` would benefit from worker-wrapper, until we add a bang. So we do.
(No need to allocate `CheapHashes` if you are goint to evaluate them right away).