### PR TITLE
Make type Hash = Word64

### DIFF
--- a/bench/macro/Bench/Database/LSMTree/Internal/BloomFilter.hs
+++ b/bench/macro/Bench/Database/LSMTree/Internal/BloomFilter.hs
@@ -18,6 +18,7 @@ import           Data.Time
 import           Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import           Data.WideWord.Word256 (Word256)
+import           Data.Word (Word64)
 import           GHC.Stats
 import           Numeric
 import           System.Mem (performMajorGC)
@@ -133,7 +134,7 @@ benchmark name description action n (subtractTime, subtractAlloc) = do
     return (timeNet, allocNet)
 
 -- | (numEntries, sizeFactor, numBits, numHashFuncs)
-type BloomFilterSizeInfo = (Int, Int, Int, Int)
+type BloomFilterSizeInfo = (Int, Int, Word64, Int)
 type SizeBase     = Int
 type RequestedFPR = Double
 
@@ -146,7 +147,7 @@ type RequestedFPR = Double
 --
 lsmStyleBloomFilters :: SizeBase -> RequestedFPR -> [BloomFilterSizeInfo]
 lsmStyleBloomFilters l1 requestedFPR =
-    [ (numEntries, sizeFactor, numBits, numHashFuncs)
+    [ (numEntries, sizeFactor, fromIntegral numBits, numHashFuncs)
     | (numEntries, sizeFactor)
         <- replicate 8 (2^(l1+0), 1)   -- 8 runs at level 1 (tiering)
         ++ replicate 8 (2^(l1+2), 4)   -- 8 runs at level 2 (tiering)
@@ -161,7 +162,7 @@ totalNumEntries filterSizes =
     sum [ numEntries | (numEntries, _, _, _) <- filterSizes ]
 
 totalNumBytes filterSizes =
-    sum [ numBits | (_,_,numBits,_) <- filterSizes ] `div` 8
+    fromIntegral $ sum [ numBits | (_,_,numBits,_) <- filterSizes ] `div` 8
 
 totalNumEntriesSanityCheck :: SizeBase -> [BloomFilterSizeInfo] -> Bool
 totalNumEntriesSanityCheck l1 filterSizes =

--- a/bloomfilter/Data/BloomFilter/BitVec64.hs
+++ b/bloomfilter/Data/BloomFilter/BitVec64.hs
@@ -23,28 +23,28 @@ import qualified Data.Vector.Primitive.Mutable as MP
 newtype BitVec64 = BV64 (P.Vector Word64)
   deriving (Eq, Show)
 
-unsafeIndex :: BitVec64 -> Int -> Bool
-unsafeIndex (BV64 bv) i = testBit (P.unsafeIndex bv j) k
+unsafeIndex :: BitVec64 -> Word64 -> Bool
+unsafeIndex (BV64 bv) i = testBit (P.unsafeIndex bv (w2i j)) (w2i k)
   where
     !j = unsafeShiftR i 6 -- `div` 64
     !k = i .&. 63         -- `mod` 64
 
 newtype MBitVec64 s = MBV64 (P.MVector s Word64)
 
-new :: Int -> ST s (MBitVec64 s)
-new s = MBV64 <$> MP.new (roundUpTo64 s)
+new :: Word64 -> ST s (MBitVec64 s)
+new s = MBV64 <$> MP.new (w2i (roundUpTo64 s))
 
-unsafeWrite :: MBitVec64 s -> Int -> Bool -> ST s ()
+unsafeWrite :: MBitVec64 s -> Word64 -> Bool -> ST s ()
 unsafeWrite (MBV64 mbv) i x = do
-    MP.unsafeModify mbv (\w -> if x then setBit w k else clearBit w k) j
+    MP.unsafeModify mbv (\w -> if x then setBit w (w2i k) else clearBit w (w2i k)) (w2i j)
   where
     !j = unsafeShiftR i 6 -- `div` 64
     !k = i .&. 63         -- `mod` 64
 
-unsafeRead :: MBitVec64 s -> Int -> ST s Bool
+unsafeRead :: MBitVec64 s -> Word64 -> ST s Bool
 unsafeRead (MBV64 mbv) i = do
-    !w <- MP.unsafeRead mbv j
-    return $! testBit w k 
+    !w <- MP.unsafeRead mbv (w2i j)
+    return $! testBit w (w2i k)
   where
     !j = unsafeShiftR i 6 -- `div` 64
     !k = i .&. 63         -- `mod` 64
@@ -58,5 +58,10 @@ unsafeFreeze (MBV64 mbv) = BV64 <$> P.unsafeFreeze mbv
 thaw :: BitVec64 -> ST s (MBitVec64 s)
 thaw (BV64 bv) = MBV64 <$> P.thaw bv
 
-roundUpTo64 :: Int -> Int
+-- this may overflow, but so be it (1^64 bits is a lot)
+roundUpTo64 :: Word64 -> Word64
 roundUpTo64 i = unsafeShiftR (i + 63) 6
+
+w2i :: Word64 -> Int
+w2i = fromIntegral
+{-# INLINE w2i #-}

--- a/bloomfilter/Data/BloomFilter/Easy.hs
+++ b/bloomfilter/Data/BloomFilter/Easy.hs
@@ -31,6 +31,7 @@ module Data.BloomFilter.Easy
 import Data.BloomFilter (Bloom)
 import Data.BloomFilter.Hash (Hashable)
 import Data.BloomFilter.Util (nextPowerOfTwo)
+import Data.Word (Word64)
 import qualified Data.ByteString as SB
 import qualified Data.BloomFilter as B
 
@@ -42,7 +43,7 @@ easyList :: (Hashable a)
          -> [a]                 -- ^ values to populate with
          -> Bloom a
 {-# SPECIALIZE easyList :: Double -> [SB.ByteString] -> Bloom SB.ByteString #-}
-easyList errRate xs = B.fromList numHashes numBits xs
+easyList errRate xs = B.fromList numHashes (fromIntegral numBits) xs
     where capacity = length xs
           (numBits, numHashes)
               | capacity > 0 = suggestSizing capacity errRate
@@ -59,7 +60,7 @@ easyList errRate xs = B.fromList numHashes numBits xs
 safeSuggestSizing
     :: Int              -- ^ expected maximum capacity
     -> Double           -- ^ desired false positive rate (0 < /e/ < 1)
-    -> Either String (Int, Int)
+    -> Either String (Word64, Int)
 safeSuggestSizing capacity errRate
     | capacity <= 0                = Left "invalid capacity"
     | errRate <= 0 || errRate >= 1 = Left "invalid error rate"
@@ -82,7 +83,7 @@ safeSuggestSizing capacity errRate
 -- invalid or out-of-range inputs.
 suggestSizing :: Int            -- ^ expected maximum capacity
               -> Double         -- ^ desired false positive rate (0 < /e/ < 1)
-              -> (Int, Int)
+              -> (Word64, Int)
 suggestSizing cap errs = either fatal id (safeSuggestSizing cap errs)
   where fatal = error . ("Data.BloomFilter.Util.suggestSizing: " ++)
 

--- a/bloomfilter/Data/BloomFilter/Hash.hs
+++ b/bloomfilter/Data/BloomFilter/Hash.hs
@@ -37,15 +37,13 @@ module Data.BloomFilter.Hash
 
 import Data.Array.Byte (ByteArray (..))
 import Data.Bits (unsafeShiftR)
-import Data.Word (Word32, Word64)
+import Data.Word (Word64)
 import XXH3 (xxh3_64bit_withSeed_ba, xxh3_64bit_withSeed_bs)
-
 import qualified Data.ByteString as SB
 import qualified Data.Primitive as P
 
--- | A hash value is 32 bits wide.  This limits the maximum size of a
--- filter to about four billion elements, or 512 megabytes of memory.
-type Hash = Word32
+-- | A hash value is 64 bits wide.
+type Hash = Word64
 
 class Hashable a where
     -- | Compute a 64-bit hash of a value.  The first salt value

--- a/bloomfilter/Data/BloomFilter/Mutable/Internal.hs
+++ b/bloomfilter/Data/BloomFilter/Mutable/Internal.hs
@@ -15,6 +15,7 @@ module Data.BloomFilter.Mutable.Internal
     , hashes
     ) where
 
+import Data.Word (Word64)
 import qualified Data.BloomFilter.BitVec64 as V
 
 import qualified Data.BloomFilter.Hash as Hash
@@ -25,7 +26,7 @@ import Prelude hiding (elem, length, notElem,
 -- | A mutable Bloom filter, for use within the 'ST' monad.
 data MBloom s a = MB {
       hashesN  :: {-# UNPACK #-} !Int
-    , size     :: {-# UNPACK #-} !Int  -- ^ size is multiple of 64
+    , size     :: {-# UNPACK #-} !Word64  -- ^ size is multiple of 64
     , bitArray :: {-# UNPACK #-} !(V.MBitVec64 s)
     }
 type role MBloom nominal nominal

--- a/bloomfilter/Data/BloomFilter/Util.hs
+++ b/bloomfilter/Data/BloomFilter/Util.hs
@@ -7,9 +7,10 @@ module Data.BloomFilter.Util
     ) where
 
 import Data.Bits ((.|.), (.&.), complement, unsafeShiftR)
+import Data.Word (Word64)
 
 -- given number.
-nextPowerOfTwo :: Int -> Int
+nextPowerOfTwo :: Word64 -> Word64
 {-# INLINE nextPowerOfTwo #-}
 nextPowerOfTwo n =
     let a = n - 1
@@ -26,5 +27,5 @@ nextPowerOfTwo n =
 -- >>> and [ ceil64 i == ceil64ref i | i <- [0..200] ]
 -- True
 --
-ceil64 :: Int -> Int
+ceil64 :: Word64 -> Word64
 ceil64 i = (i + 63) .&. complement 0x3f

--- a/src/utils/Database/LSMTree/Extras.hs
+++ b/src/utils/Database/LSMTree/Extras.hs
@@ -59,7 +59,7 @@ mkBloomST requestedFPR xs = runST $ do
 --   rounding of th ebits.
 mkBloomST_Monkey :: Hashable a => Double -> BloomMaker a
 mkBloomST_Monkey requestedFPR xs = runST $ do
-    b <- Bloom.new numHashFuncs numBits
+    b <- Bloom.new numHashFuncs (fromIntegral numBits)
     mapM_ (Bloom.insert b) xs
     Bloom.freeze b
   where

--- a/test/Test/Database/LSMTree/Internal/BloomFilter.hs
+++ b/test/Test/Database/LSMTree/Internal/BloomFilter.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE ViewPatterns #-}
 module Test.Database.LSMTree.Internal.BloomFilter (tests) where
 
+import           Data.Bits ((.&.))
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as SBS
@@ -15,14 +17,17 @@ tests :: TestTree
 tests = testGroup "Database.LSMTree.Internal.BloomFilter"
     [ testProperty "roundtrip" roundtrip_prop
       -- a specific case: 300 bits is just under 5x 64 bit words
-    , testProperty "roundtrip-3-300" $ roundtrip_prop (Positive (Small 3)) (Positive 300)
+    , testProperty "roundtrip-3-300" $ roundtrip_prop (Positive (Small 3)) 300
     ]
 
-roundtrip_prop :: Positive (Small Int) -> Positive Int ->  [Word64] -> Property
-roundtrip_prop (Positive (Small hfN)) (Positive bits) ws =
+roundtrip_prop :: Positive (Small Int) -> Word64 ->  [Word64] -> Property
+roundtrip_prop (Positive (Small hfN)) (limitBits -> bits) ws =
     counterexample (show sbs) $
     Right lhs === rhs
   where
     lhs = BF.fromList hfN bits ws
     sbs = SBS.toShort (LBS.toStrict (B.toLazyByteString (bloomFilterToBuilder lhs)))
     rhs = bloomFilterFromSBS sbs
+
+limitBits :: Word64 -> Word64
+limitBits b = b .&. 0xffffff


### PR DESCRIPTION
We need to be more careful with remainder operations, we do them on unsigned Word64s.

I limit the size of bloomfilter to 2^48; which is hopefully enough.

Now the elemCheapHashes is *slower*, this is expected: modulus on 64 bit words is more expensive.

Before

```
Benchmarking baseline ...
(This is the cost of just computing the keys.)
Finished.
Time total:        0.12 seconds
Alloc total:       1.20e9 bytes
Time net:          0.12 seconds
Alloc net:         1.20e9 bytes
Time net per key:  4.89e-9 seconds
Alloc net per key: 48.00 bytes

Benchmarking makeCheapHashes ...
(This includes the cost of hashing the keys, less the cost of computing the keys)
Finished.
Time total:        0.34 seconds
Alloc total:       1.20e9 bytes
Time net:          0.22 seconds
Alloc net:         -752.00 bytes
Time net per key:  8.62e-9 seconds
Alloc net per key: -3.01e-5 bytes

Benchmarking elemCheapHashes ...
(this is the simple one-by-one lookup, less the cost of computing and hashing the keys)
Finished.
Time total:        31.75 seconds
Alloc total:       1.20e9 bytes
Time net:          31.41 seconds
Alloc net:         0.00 bytes
Time net per key:  1.26e-6 seconds
Alloc net per key: 0.00 bytes
```

After

```
Benchmarking baseline ...
(This is the cost of just computing the keys.)
Finished.
Time total:        0.12 seconds
Alloc total:       1.20e9 bytes
Time net:          0.12 seconds
Alloc net:         1.20e9 bytes
Time net per key:  4.68e-9 seconds
Alloc net per key: 48.00 bytes

Benchmarking makeCheapHashes ...
(This includes the cost of hashing the keys, less the cost of computing the keys)
Finished.
Time total:        0.30 seconds
Alloc total:       1.20e9 bytes
Time net:          0.18 seconds
Alloc net:         -752.00 bytes
Time net per key:  7.36e-9 seconds
Alloc net per key: -3.01e-5 bytes

Benchmarking elemCheapHashes ...
(this is the simple one-by-one lookup, less the cost of computing and hashing the keys)
Finished.
Time total:        36.34 seconds
Alloc total:       1.20e9 bytes
Time net:          36.04 seconds
Alloc net:         0.00 bytes
Time net per key:  1.44e-6 seconds
Alloc net per key: 0.00 bytes
```